### PR TITLE
Add external-calculator shell mode for enerzyme listen

### DIFF
--- a/docs/getting_started/active_learning.rst
+++ b/docs/getting_started/active_learning.rst
@@ -394,7 +394,7 @@ Two patterns seed structures before or alongside AL:
 - Per-reaction subdirectories with :code:`reactant_opt.yaml`, :code:`scan.yaml`, :code:`product_opt.yaml`
 - :code:`local_minima/` and :code:`rate_determining_ts/` summaries
 
-For PLUMED CV scans, :code:`-pp` (plugin key) and :code:`-psc` (CV parameter YAML) are both required. For bond-distance scans, :code:`-q` accepts either a TeraChem input or a YAML scan config (see :doc:`enhanced_sampling`).
+For PLUMED CV scans, :code:`-pp` (plugin key) and :code:`-psc` (CV parameter YAML) are both required. For bond-distance scans, :code:`-q` accepts either a TeraChem input or a YAML scan config (optional :code:`charge` skips PDB charge derivation; see :doc:`enhanced_sampling`).
 
 Neither pattern replaces Enerzyme's internal :code:`Trainer.active_learning_params` dataset AL.
 

--- a/docs/getting_started/bond_and_utilities.rst
+++ b/docs/getting_started/bond_and_utilities.rst
@@ -81,7 +81,7 @@ Automated opt → scan → opt loops for reaction-coordinate exploration:
         -psc cv_params.yaml \
         -n 25
 
-- :code:`-q` — TeraChem input with :code:`constraint_freeze` / :code:`constraint_scan`, **or** a YAML scan config (see :doc:`enhanced_sampling`)
+- :code:`-q` — TeraChem input with :code:`constraint_freeze` / :code:`constraint_scan`, **or** a YAML scan config (:code:`reference_pdb`, :code:`freeze_index_types`, optional :code:`charge`; see :doc:`enhanced_sampling`)
 - :code:`-pp` / :code:`-psc` — PLUMED CV scan; both flags required together
 - :code:`enerzymette update_terachem_scan` — refresh bond-scan coordinates in a TeraChem input after geometry update
 
@@ -96,12 +96,18 @@ NNP-driven NEB via ORCA and :code:`enerzyme listen`:
         -r reactant.xyz \
         -p product.xyz \
         -o neb_out/ \
-        -m model_dir/ \
-        -q reference.in \
-        -c server.yaml \
-        -n 25 -b 5000
+        -q neb_config.yaml \
+        -c server_uma.yaml \
+        -cp uma \
+        -t ts_guess.xyz \
+        -n 8 -b 5001
 
-See :doc:`server_and_enerzymette` for server setup.
+- :code:`-q` — TeraChem reference input **or** YAML neb config (:code:`reference_pdb`, :code:`freeze_index_types`; optional :code:`charge` / :code:`reference_sdf` / :code:`multiplicity`)
+- :code:`-cp` — external calculator patch (path or key such as :code:`uma`); needed for shell-mode listen
+- :code:`-t` — optional TS guess structure for ORCA :code:`%neb TS`
+- :code:`-m` — model directory (optional when the server runs with :code:`internal_calculator_weight: 0`)
+
+See :doc:`enhanced_sampling` for a sample :code:`neb_config.yaml` and :doc:`server_and_enerzymette` for server setup.
 
 Quick reference
 ---------------

--- a/docs/getting_started/enhanced_sampling.rst
+++ b/docs/getting_started/enhanced_sampling.rst
@@ -106,7 +106,7 @@ Enerzymette launchers
 :code:`enerzymette enerzyme_scan`
     Flexible bond or PLUMED CV scans. For each elementary reaction: optimize reactant → scan → optimize product → analyze path. Key flags:
 
-    - :code:`-q` — TeraChem input **or** YAML **scan config** (charge, frozen atoms, scan bond)
+    - :code:`-q` — TeraChem input **or** YAML **scan config** (:code:`reference_pdb`, :code:`freeze_index_types`, scan bond)
     - :code:`-pp` — PLUMED plugin key (e.g. :code:`sammt`); switches to :code:`plumed_scan`
     - :code:`-psc` — YAML with CV parameters (:code:`lower_bound`, :code:`reference_pdb_file`, etc.); **required** when :code:`-pp` is set
 
@@ -115,7 +115,8 @@ Enerzymette launchers
     .. code-block:: yaml
 
         reference_pdb: cluster.pdb
-        reference_sdf: ligands.sdf
+        reference_sdf: ligands.sdf   # optional; used with enerzyme bond when charge is omitted
+        charge: 0                    # optional; if set, skip PDB charge derivation
         multiplicity: 1
         freeze_index_types: [backbone, Calpha]
         constraint_scan:
@@ -124,10 +125,39 @@ Enerzymette launchers
                 substrate: G
                 nucleophile: "O2'"
 
-    Supporting utility: :code:`enerzymette update_terachem_scan` refreshes coordinates in a TeraChem scan input after a structure update.
+    When :code:`charge` is omitted, Enerzymette derives it via :code:`enerzyme bond` on :code:`reference_pdb` (optionally with :code:`reference_sdf`). Supporting utility: :code:`enerzymette update_terachem_scan` refreshes coordinates in a TeraChem scan input after a structure update.
 
 :code:`enerzymette enerzyme_neb`
-    NNP-driven NEB through ORCA ExtOpt and a running :code:`enerzyme listen` server. Requires :code:`-r`, :code:`-p`, :code:`-q` (reference TeraChem input), :code:`-c` (server config), and :code:`-m` (model directory). See :doc:`server_and_enerzymette`.
+    NNP-driven NEB through ORCA ExtOpt and a running :code:`enerzyme listen` server. Key flags:
+
+    - :code:`-r` / :code:`-p` — reactant and product XYZ
+    - :code:`-q` — TeraChem reference input **or** YAML **neb config** (:code:`reference_pdb`, :code:`freeze_index_types`; optional :code:`charge`, :code:`reference_sdf`, :code:`multiplicity`)
+    - :code:`-c` — server config (for pure external UMA, use :code:`server_uma.yaml` with :code:`internal_calculator_weight: 0`)
+    - :code:`-cp` — external calculator patch path or registry key (e.g. :code:`uma`); required in shell mode
+    - :code:`-t` — optional initial TS guess XYZ (enables ORCA :code:`%neb TS`)
+    - :code:`-m` — trained model directory (optional when :code:`internal_calculator_weight` is 0)
+
+    Example neb config (:code:`-q neb_config.yaml`):
+
+    .. code-block:: yaml
+
+        reference_pdb: cluster.pdb
+        freeze_index_types:
+            - backbone
+        charge: 0          # optional; if omitted, charge is derived via enerzyme bond
+        multiplicity: 1
+        # reference_sdf: ligands.sdf
+
+    Example launcher call (external-calculator shell):
+
+    .. code-block:: bash
+
+        enerzymette enerzyme_neb \
+            -r reactant.xyz -p product.xyz -o neb_out/ \
+            -q neb_config.yaml -c server_uma.yaml \
+            -cp uma -t ts_guess.xyz -n 8 -b 5001
+
+    See :doc:`server_and_enerzymette` for listen / shell-mode setup.
 
 :code:`enerzymette enerzyme_active_learning`
     Runs the external active-learning loop around Enerzyme simulation, extraction, QM annotation, and retraining. :code:`--initial-scan` runs chained :code:`plumed_scan` jobs before iteration 0 to populate a structure pool. See :doc:`active_learning` for the expected task-folder layout and template input files.

--- a/docs/getting_started/server_and_enerzymette.rst
+++ b/docs/getting_started/server_and_enerzymette.rst
@@ -92,7 +92,9 @@ Relevant launchers:
 | :code:`enerzymette enerzyme_active_learning` | PLUMED steered MD AL iterations    |
 +-----------------------------------+-----------------------------------------------+
 
-:code:`enerzyme_neb` and :code:`enerzyme_scan` start :code:`enerzyme listen` when needed; :code:`enerzyme_active_learning` invokes :code:`enerzyme simulate` directly. See :doc:`enhanced_sampling` for PLUMED plugin details. End-to-end example: :code:`example/NNP4MTase`.
+:code:`enerzyme_neb` and :code:`enerzyme_scan` start :code:`enerzyme listen` when needed; :code:`enerzyme_active_learning` invokes :code:`enerzyme simulate` directly.
+
+For NEB, :code:`-q` may be a TeraChem input or a YAML :code:`neb_config` (:code:`reference_pdb`, :code:`freeze_index_types`; optional :code:`charge`). In external-calculator shell mode, pass the same :code:`-cp` the launcher should forward to :code:`enerzyme listen` (and omit :code:`-m` when :code:`internal_calculator_weight` is 0). Optional :code:`-t` supplies an initial TS guess. See :doc:`enhanced_sampling` for PLUMED plugins, scan/neb YAML examples, and CLI details. End-to-end example: :code:`example/NNP4MTase`.
 
 Architecture sketch
 -------------------

--- a/docs/getting_started/server_and_enerzymette.rst
+++ b/docs/getting_started/server_and_enerzymette.rst
@@ -13,12 +13,19 @@ Starting the server
 Arguments:
 
 - :code:`-c` — server config (minimal YAML; see below)
-- :code:`-m` — trained model directory
+- :code:`-m` — trained model directory (optional in external-calculator shell mode)
 - :code:`-mc` — model config (defaults to :code:`model_dir/config.yaml`)
 - :code:`-b` — bind address (host:port)
 - :code:`-o` — output directory for server logs and artifacts
+- :code:`-cp` — optional external calculator patch (:code:`.py`), same as :code:`simulate`
 
-There is no separate :code:`listen.yaml` in the repository. Reuse a lightweight config derived from :code:`predict.yaml` or an empty :code:`Datahub`-only stub—the server loads active models from :code:`-mc`.
+External-calculator shell (no trained Enerzyme model):
+
+.. code-block:: bash
+
+    enerzyme listen -c enerzyme/config/server_uma.yaml -o server_out/ -b 0.0.0.0:5000 -cp /path/to/uma.py
+
+Set :code:`Server.internal_calculator_weight: 0` and omit :code:`uncertainty_calculator`. The server loads only the :code:`-cp` factory named by :code:`Server.external_calculator`.
 
 Minimal server config
 ---------------------
@@ -28,7 +35,7 @@ Minimal server config
     Datahub:
         preload: true
 
-The listen process reads :code:`Modelhub` from the model config, loads all :code:`active: true` models, and exposes them via Flask/Waitress.
+With an internal model, the listen process reads :code:`Modelhub` from the model config, loads all :code:`active: true` models, and exposes them via Flask/Waitress. Hybrid / shell keys live under :code:`Server:` — see :doc:`/user_guide/integrations/server_mode`.
 
 Sending a request (client)
 --------------------------
@@ -95,7 +102,8 @@ Architecture sketch
     Client / Enerzymette  --POST /calculate-->  enerzyme listen
                                                       |
                                                       v
-                                              ASECalculator + model
+                                              ASECalculator
+                                           (internal and/or -cp)
 
 Related pages
 -------------

--- a/docs/user_guide/integrations/enerzymette.rst
+++ b/docs/user_guide/integrations/enerzymette.rst
@@ -21,10 +21,10 @@ Main launchers
     Outer AL loop: simulate → predict/extract → annotate → train. Manages a per-task **structure pool** and rewrites YAML each round. See :doc:`/user_guide/workflows/active_learning`.
 
 :code:`enerzymette enerzyme_scan`
-    Chained reaction-coordinate scans (bond-distance or PLUMED CV). Reads system settings from a TeraChem input or a YAML **scan config** (:code:`-q`). PLUMED mode requires :code:`-pp` and :code:`-psc`.
+    Chained reaction-coordinate scans (bond-distance or PLUMED CV). Reads system settings from a TeraChem input or a YAML **scan config** (:code:`-q`: :code:`reference_pdb`, :code:`freeze_index_types`, scan bond; optional :code:`charge` skips :code:`enerzyme bond` charge derivation). PLUMED mode requires :code:`-pp` and :code:`-psc`.
 
 :code:`enerzymette enerzyme_neb`
-    NNP-driven NEB via ORCA ExtOpt and :code:`enerzyme listen`. See :doc:`/getting_started/server_and_enerzymette`.
+    NNP-driven NEB via ORCA ExtOpt and :code:`enerzyme listen`. :code:`-q` accepts a TeraChem reference **or** YAML **neb config** (same freeze/charge pattern as scan). Pass :code:`-cp` for external-calculator shell mode and optional :code:`-t` for an initial TS guess. See :doc:`/getting_started/enhanced_sampling` and :doc:`/getting_started/server_and_enerzymette`.
 
 PLUMED CV plugins
 -----------------

--- a/docs/user_guide/integrations/server_mode.rst
+++ b/docs/user_guide/integrations/server_mode.rst
@@ -6,17 +6,25 @@ Long-running HTTP service for repeated energy/force requests. Useful with workfl
 Commands
 --------
 
-Start server:
+Start server (trained Enerzyme model):
 
 .. code-block:: bash
 
     enerzyme listen -c server.yaml -m model_dir/ -o server_out/ -b 0.0.0.0:5000 -mc config.yaml
+
+Start server as an **external-calculator shell** (no trained Enerzyme model):
+
+.. code-block:: bash
+
+    enerzyme listen -c server_uma.yaml -o server_out/ -b 0.0.0.0:5000 -cp /path/to/uma.py
 
 Client request:
 
 .. code-block:: bash
 
     enerzyme request -u http://127.0.0.1:5000 -f ORCA -i input.extinp.tmp -k FF02
+
+In shell mode the default :code:`model_key` is :code:`external` (omit :code:`-k` or pass :code:`-k external`).
 
 Shutdown:
 
@@ -28,7 +36,7 @@ Implementation
 --------------
 
 - :code:`enerzyme/listen.py` — Flask/Waitress, route :code:`POST /calculate`
-- :code:`enerzyme/tasks/server.py` — model forward pass
+- :code:`enerzyme/tasks/server.py` — ASECalculator bridge (internal MLFF and/or external patch)
 - :code:`enerzyme/request.py` — ORCA :code:`.extinp.tmp` → :code:`.engrad` bridge
 
 Request format
@@ -59,12 +67,38 @@ JSON with :code:`outputs` (energy, forces, etc.) and :code:`units` (:code:`Hartr
 Multi-model serving
 -------------------
 
-:code:`listen` loads all :code:`active: true` models from :code:`config.yaml`. Clients select via :code:`model_key` (:code:`-k`).
+:code:`listen` loads all :code:`active: true` models from :code:`config.yaml` when an internal calculator is active. Clients select via :code:`model_key` (:code:`-k`).
+
+External calculator and shell mode
+----------------------------------
+
+Server YAML mirrors the simulate hybrid keys under :code:`Server:`:
+
+.. code-block:: yaml
+
+    Server:
+      cuda: true
+      dtype: float64
+      neighbor_list: full
+      Hartree_in_E: 1.0
+      external_calculator:
+        name: uma_calculator
+        weight: 1.0
+        params:
+          model: uma-s-1p2
+          task: omol
+          device: cuda
+      internal_calculator_weight: 0.0
+
+- Supply :code:`-cp` pointing to a :code:`.py` patch that exposes :code:`get_<name>` (same contract as :code:`enerzyme simulate`).
+- When :code:`internal_calculator_weight` is :code:`0` and :code:`uncertainty_calculator` is omitted, the server runs in **shell mode**: no :code:`-m` / Modelhub / checkpoint is required; only the external patch is loaded.
+- If :code:`uncertainty_calculator` (e.g. UDD) is set, an internal model is still required even when its energy weight is zero.
+- Bundled example: :code:`enerzyme/config/server_uma.yaml`.
 
 Server config
 -------------
 
-No dedicated :code:`listen.yaml` in the repository. A minimal config may only need:
+For pure internal serving, a minimal config may only need:
 
 .. code-block:: yaml
 
@@ -76,7 +110,7 @@ Model architecture and transforms come from :code:`-mc` / :code:`model_dir/confi
 Deployment notes
 ----------------
 
-- Model load time is paid once at startup — amortize over many requests
+- Model (or external calculator) load time is paid once at startup — amortize over many requests
 - Bind address :code:`-b` controls network exposure
 - Logs go to :code:`out_dir` and waitress logger (wired to Enerzyme logger)
 - For batch evaluation on static datasets, prefer :code:`enerzyme predict`

--- a/enerzyme/cli.py
+++ b/enerzyme/cli.py
@@ -134,14 +134,17 @@ def get_parser():
     parser_listen.add_argument('-c', '--config_path', type=str, default='', 
         help='listen config'
     )
-    parser_listen.add_argument('-m', '--model_dir', type=str,
-                    help='the directory of models')
+    parser_listen.add_argument('-m', '--model_dir', type=str, default=None,
+                    help='the directory of models (optional in external-calculator shell mode)')
     parser_listen.add_argument('-o', '--out_dir', type=str, default='../results',
         help='the output directory for saving artifact')
     parser_listen.add_argument('-b', '--bind', type=str, default='0.0.0.0:5000',
         help='the address to bind to')
     parser_listen.add_argument('-mc', '--model_config_path', type=str, default=None,
         help='the model configuration file'
+    )
+    parser_listen.add_argument('-cp', '--calculator_patch', type=str, default=None,
+        help='the external calculator patch path'
     )
 
     parser_request = subparsers.add_parser(
@@ -255,7 +258,8 @@ def listen(args):
         model_dir=args.model_dir, 
         out_dir=args.out_dir,
         bind=args.bind,
-        model_config_path=args.model_config_path
+        model_config_path=args.model_config_path,
+        calculator_patch=args.calculator_patch,
     ).listen()
 
 

--- a/enerzyme/config/server_uma.yaml
+++ b/enerzyme/config/server_uma.yaml
@@ -1,0 +1,16 @@
+Server:
+  cuda: true
+  dtype: float64
+  neighbor_list: full
+  Hartree_in_E: 1.0
+  # Pure external-calculator shell: no trained Enerzyme model required.
+  # Start with:
+  #   enerzyme listen -c server_uma.yaml -o out/ -b 0.0.0.0:5000 -cp /path/to/uma.py
+  external_calculator:
+    name: uma_calculator
+    weight: 1.0
+    params:
+      model: uma-s-1p2
+      task: omol
+      device: cuda
+  internal_calculator_weight: 0.0

--- a/enerzyme/listen.py
+++ b/enerzyme/listen.py
@@ -1,41 +1,129 @@
 import os
 import time
 from typing import Optional
+
 from flask import Flask, request, jsonify
 import waitress
 import logging
+
 from .utils import YamlHandler, logger
 from .data.transform import Transform
 from .models import get_model_str, build_model, get_pretrain_path
 from .tasks.server import Server
+from .tasks.calculator import _init_patch_module, get_patched_calculator
 
 
 app = Flask("enerzyme")
 _ff_listen_instance = None
 
+
 class FFListen:
-    def __init__(self, config_path=str, model_dir=str, out_dir=str, bind=str, model_config_path: Optional[str] = None):
+    def __init__(
+        self,
+        config_path=str,
+        model_dir: Optional[str] = None,
+        out_dir=str,
+        bind=str,
+        model_config_path: Optional[str] = None,
+        calculator_patch: Optional[str] = None,
+    ):
         self.model_dir = model_dir
         self.config = YamlHandler(config_path).read_yaml()
         self.out_dir = out_dir
         self.servers = dict()
-        model_config_path = os.path.join(self.model_dir, 'config.yaml') if model_config_path is None else model_config_path
+        self.bind = bind
+        self.calculator_patch = calculator_patch
+        self.calculator_patch_module = None
+
+        server_cfg = self.config.get("Server", dict())
+        self.external_calculator_config = server_cfg.get("external_calculator", dict())
+        self.uncertainty_calculator_config = server_cfg.get("uncertainty_calculator", None)
+        self.internal_calculator_weight = server_cfg.get("internal_calculator_weight", 1.0)
+
+        self.shell_mode = (
+            self.internal_calculator_weight == 0
+            and self.uncertainty_calculator_config is None
+        )
+
+        self.external_calculator = None
+        if self.calculator_patch is not None:
+            self.calculator_patch_module = _init_patch_module(self.calculator_patch)
+            logger.info(f"Initialized calculator patch module: {self.calculator_patch}")
+            self.external_calculator = get_patched_calculator(
+                self.calculator_patch_module,
+                self.external_calculator_config,
+            )
+            logger.info(
+                "Initialized external calculator: "
+                f"{self.external_calculator_config.get('name', None)}"
+            )
+
+        if self.shell_mode:
+            if self.external_calculator is None:
+                raise ValueError(
+                    "Shell mode (internal_calculator_weight=0 without uncertainty_calculator) "
+                    "requires -cp / --calculator_patch and Server.external_calculator.name"
+                )
+            self.servers["external"] = Server(
+                self.config,
+                model=None,
+                model_path=None,
+                out_dir=self.out_dir,
+                transform=None,
+                external_calculator=self.external_calculator,
+                external_calculator_config=self.external_calculator_config,
+                internal_calculator_weight=self.internal_calculator_weight,
+                uncertainty_calculator_config=self.uncertainty_calculator_config,
+            )
+            logger.info("Listening in external-calculator shell mode (no internal MLFF)")
+            return
+
+        if self.model_dir is None:
+            raise ValueError(
+                "model_dir (-m) is required when internal calculator is active "
+                "(internal_calculator_weight != 0 or uncertainty_calculator is set)"
+            )
+
+        model_config_path = (
+            os.path.join(self.model_dir, "config.yaml")
+            if model_config_path is None
+            else model_config_path
+        )
         model_config = YamlHandler(model_config_path).read_yaml()
-        logger.info('Model Config: {}'.format(model_config))
-        self.transform = Transform(model_config.Datahub.get("global_transforms", model_config.Datahub.get("transforms", None)), simulation_mode=True)
+        logger.info("Model Config: {}".format(model_config))
+        self.transform = Transform(
+            model_config.Datahub.get(
+                "global_transforms",
+                model_config.Datahub.get("transforms", None),
+            ),
+            simulation_mode=True,
+        )
         for FF_key, FF_params in model_config.Modelhub.internal_FFs.items():
             if FF_params.get("active", False):
                 self._init_model(FF_key, FF_params)
         for FF_key, FF_params in model_config.Modelhub.external_FFs.items():
             if FF_params.get("active", False):
                 self._init_model(FF_key, FF_params)
-        self.bind = bind
-    
+        if not self.servers:
+            raise ValueError(
+                "No active force fields found in Modelhub; set active: true or use shell mode"
+            )
+
     def _init_model(self, FF_key, FF_params):
         model_str = get_model_str(FF_key, FF_params)
         model = build_model(FF_params.architecture, FF_params.layers, FF_params.build_params)
         model_path = get_pretrain_path(os.path.join(self.model_dir, model_str), "best")
-        self.servers[FF_key] = Server(self.config, model=model, model_path=model_path, out_dir=self.out_dir, transform=self.transform)
+        self.servers[FF_key] = Server(
+            self.config,
+            model=model,
+            model_path=model_path,
+            out_dir=self.out_dir,
+            transform=self.transform,
+            external_calculator=self.external_calculator,
+            external_calculator_config=self.external_calculator_config,
+            internal_calculator_weight=self.internal_calculator_weight,
+            uncertainty_calculator_config=self.uncertainty_calculator_config,
+        )
 
     def run_calculate(self):
         info = request.get_json()
@@ -43,18 +131,24 @@ class FFListen:
         start_time = time.time()
         raw_outputs = self.servers[model_key].calculate(info)
         end_time = time.time()
-        new_outputs = {k: v[0].tolist() if hasattr(v[0], "tolist") else v[0] for k, v in raw_outputs.items()}
+        new_outputs = {
+            k: v[0].tolist() if hasattr(v[0], "tolist") else v[0]
+            for k, v in raw_outputs.items()
+        }
         results = {"outputs": new_outputs}
         results["units"] = {
             "Hartree_in_E": self.servers[model_key].Hartree_in_E,
-            "Bohr_in_R": self.servers[model_key].Bohr_in_R
+            "Bohr_in_R": self.servers[model_key].Bohr_in_R,
         }
-        logger.info(f"Serving results for {info['input_file']} with model {model_key} in {end_time - start_time} seconds")
+        logger.info(
+            f"Serving results for {info.get('input_file', '<unknown>')} "
+            f"with model {model_key} in {end_time - start_time} seconds"
+        )
         return jsonify(results)
-    
+
     def listen(self):
         # Configure waitress logger to use our logger's handlers
-        waitress_logger = logging.getLogger('waitress')
+        waitress_logger = logging.getLogger("waitress")
         waitress_logger.handlers = []  # Clear existing handlers
         waitress_logger.addHandler(logger.handlers[0])  # Add console handler
         if len(logger.handlers) > 1:
@@ -69,21 +163,21 @@ class FFListen:
         logger.info("Stop signal received")
 
 
-@app.route('/calculate', methods=['POST'])
+@app.route("/calculate", methods=["POST"])
 def run():
     return _ff_listen_instance.run_calculate()
 
 
-@app.route('/shutdown', methods=['POST'])
+@app.route("/shutdown", methods=["POST"])
 def shutdown():
     import threading
     import os
-    
+
     def shutdown_server():
         _ff_listen_instance.stop_signal()
         time.sleep(1)  # Give time for the response to be sent
         os._exit(0)  # Force exit the process
-    
+
     # Start shutdown in a separate thread to allow response to be sent
     threading.Thread(target=shutdown_server).start()
     return jsonify({"message": "Server shutdown initiated"}), 200

--- a/enerzyme/tasks/calculator.py
+++ b/enerzyme/tasks/calculator.py
@@ -167,10 +167,18 @@ class ASECalculator(Calculator):
         internal_results, biases = dict(), dict()
         if self.use_internal_calculator:
             internal_results, biases = self._calculate_internal(atoms)
-        external_calculator_properties = ['energy', 'forces']
+        # External ASE calculators often only implement energy/forces; do not
+        # pass dipole/charges even if the caller requested them.
+        external_calculator_properties = [
+            p for p in properties if p in ("energy", "forces")
+        ]
         external_results = dict()
-        if self.use_external_calculator:
-            self.external_calculator.calculate(atoms, properties=properties, system_changes=system_changes)
+        if self.use_external_calculator and external_calculator_properties:
+            self.external_calculator.calculate(
+                atoms,
+                properties=external_calculator_properties,
+                system_changes=system_changes,
+            )
             for property in external_calculator_properties:
                 external_results[property] = self.external_calculator.results[property]
 

--- a/enerzyme/tasks/calculator.py
+++ b/enerzyme/tasks/calculator.py
@@ -33,7 +33,7 @@ class ASECalculator(Calculator):
 
     def __init__(
         self,
-        model: Module,
+        model: Optional[Module]=None,
         restart: Optional[str]=None,
         label: Optional[str]=None,
         atoms: Optional[ase.Atoms]=None,
@@ -71,6 +71,19 @@ class ASECalculator(Calculator):
             self.external_calculator_weight = external_calculator_config.get("weight", 0.0)
             self.use_external_calculator = True
         self.uncertainty_calculator_config = uncertainty_calculator_config
+        self.use_internal_calculator = (
+            self.internal_calculator_weight != 0 or self.uncertainty_calculator_config is not None
+        )
+        if self.use_internal_calculator and self.model is None:
+            raise ValueError(
+                "Internal calculator is required (non-zero internal_calculator_weight "
+                "or uncertainty_calculator) but model is None"
+            )
+        if not self.use_internal_calculator and not self.use_external_calculator:
+            raise ValueError(
+                "No calculator is active: set a non-zero internal_calculator_weight "
+                "and/or provide an external_calculator"
+            )
 
     def _calculate_UDD(self, output: Dict[str, Any], A: float, B: float, NM: Optional[int]=None) -> Dict[str, Any]:
         results, biases = dict(), dict()
@@ -151,23 +164,27 @@ class ASECalculator(Calculator):
 
     def calculate(self, atoms=None, properties=["energy", "forces", "dipole", "charges"], system_changes=all_changes) -> None:
         Calculator.calculate(self, atoms, properties, system_changes)
-        if self.internal_calculator_weight != 0 or self.uncertainty_calculator_config is not None:
+        internal_results, biases = dict(), dict()
+        if self.use_internal_calculator:
             internal_results, biases = self._calculate_internal(atoms)
+        external_calculator_properties = ['energy', 'forces']
+        external_results = dict()
         if self.use_external_calculator:
-            external_calculator_properties = ['energy', 'forces']  
             self.external_calculator.calculate(atoms, properties=properties, system_changes=system_changes)
-            external_results = dict()
             for property in external_calculator_properties:
                 external_results[property] = self.external_calculator.results[property]
-        
+
         for property in properties:
             if self.use_external_calculator and property in external_calculator_properties:
                 if self.internal_calculator_weight == 0:
                     self.results[property] = self.external_calculator_weight * external_results[property]
                 else:
                     self.results[property] = self.internal_calculator_weight * internal_results[property] + self.external_calculator_weight * external_results[property]
-            else:
+            elif property in internal_results:
                 self.results[property] = self.internal_calculator_weight * internal_results[property]
+            else:
+                # Fully external shell: skip properties the external calc does not provide
+                continue
 
             if self.uncertainty_calculator_config is not None and property in ["energy", "forces"]:
                 self.results[property] += biases[property]

--- a/enerzyme/tasks/server.py
+++ b/enerzyme/tasks/server.py
@@ -1,51 +1,97 @@
-from addict import Dict
-from ase.units import Bohr
+from typing import Any, Dict, Optional
+
+from addict import Dict as AddictDict
+from ase import Atoms
+from ase.calculators.calculator import Calculator
+from ase.units import Bohr, Hartree
+import numpy as np
 import torch
 from torch.nn import Module
+
 from ..data.transform import Transform
-from ..data.neighbor_list import full_neighbor_list
+from .calculator import ASECalculator
 from .trainer import DTYPE_MAPPING, _load_state_dict
-from .batch import _decorate_batch_input, _to_device, _decorate_batch_output
 
 
 class Server:
-    def __init__(self, config: Dict, model: Module, model_path: str, out_dir: str, transform: Transform):
+    def __init__(
+        self,
+        config: AddictDict,
+        model: Optional[Module] = None,
+        model_path: Optional[str] = None,
+        out_dir: Optional[str] = None,
+        transform: Optional[Transform] = None,
+        external_calculator: Optional[Calculator] = None,
+        external_calculator_config: Optional[Dict[str, Any]] = None,
+        internal_calculator_weight: float = 1.0,
+        uncertainty_calculator_config: Optional[Dict[str, Any]] = None,
+    ):
         self.neighbor_list_type = config.Server.get("neighbor_list", "full")
-        self.cuda = config.Server.get('cuda', False)
+        self.cuda = config.Server.get("cuda", False)
         self.dtype = DTYPE_MAPPING[config.Server.get("dtype", "float64")]
         self.Hartree_in_E = config.Server.get("Hartree_in_E", 1)
         self.Bohr_in_R = config.Server.get("Bohr_in_R", Bohr)
         self.device = torch.device("cuda:0" if torch.cuda.is_available() and self.cuda else "cpu")
-        # single ff simulation
-        self.model = model.to(self.device).type(self.dtype)
-        _load_state_dict(model, self.device, model_path, inference=True)
-        self.model.eval()
-        self.calculator = None
         self.out_dir = out_dir
         self.transform = transform
-        
+        self.internal_calculator_weight = internal_calculator_weight
+        self.uncertainty_calculator_config = uncertainty_calculator_config
+        self.external_calculator_config = external_calculator_config or dict()
+        self.use_internal_calculator = (
+            self.internal_calculator_weight != 0 or self.uncertainty_calculator_config is not None
+        )
+
+        if self.use_internal_calculator:
+            if model is None or model_path is None:
+                raise ValueError(
+                    "Internal calculator requires a loaded model and model_path"
+                )
+            self.model = model.to(self.device).type(self.dtype)
+            _load_state_dict(self.model, self.device, model_path, inference=True)
+            self.model.eval()
+        else:
+            self.model = None
+
+        self.calculator = ASECalculator(
+            model=self.model,
+            device=self.device,
+            dtype=self.dtype,
+            transform=self.transform,
+            neighbor_list_type=self.neighbor_list_type,
+            Hartree_in_E=self.Hartree_in_E,
+            internal_calculator_weight=self.internal_calculator_weight,
+            uncertainty_calculator_config=self.uncertainty_calculator_config,
+            external_calculator=external_calculator,
+            external_calculator_config=self.external_calculator_config,
+        )
+
     def calculate(self, info):
         features = info.get("features", None)
         if features is None:
             return {}
-        if features["N"] is None:
+        if features.get("N") is None:
             features["N"] = len(features["Ra"])
-        if self.neighbor_list_type == "full":
-            idx_i, idx_j = full_neighbor_list(features["N"])
-            features["idx_i"] = idx_i
-            features["idx_j"] = idx_j
-            features["N_pair"] = len(idx_i)
-        net_input, _ = _decorate_batch_input(
-            batch=[(features, None)],
-            device=self.device,
-            dtype=self.dtype
+
+        atoms = Atoms(
+            numbers=np.asarray(features["Za"]),
+            positions=np.asarray(features["Ra"]),
         )
-        net_input, _ = _to_device((net_input, {}), self.device)
-        net_output = self.model(net_input)
-        output, _ = _decorate_batch_output(
-            output=net_output,
-            features=net_input,
-            targets=None
+        atoms.info["charge"] = features.get("Q", 0)
+        atoms.info["spin"] = features.get("S", 0) + 1
+
+        self.calculator.calculate(
+            atoms,
+            properties=["energy", "forces", "dipole", "charges"],
         )
-        self.transform.inverse_transform(output)
+        results = self.calculator.results
+        inv = self.Hartree_in_E / Hartree
+
+        output = {
+            "E": [np.asarray(results["energy"]).reshape(()) * inv],
+            "Fa": [np.asarray(results["forces"]) * inv],
+        }
+        if "dipole" in results:
+            output["M2"] = [np.asarray(results["dipole"])]
+        if "charges" in results:
+            output["Qa"] = [np.asarray(results["charges"])]
         return output


### PR DESCRIPTION
## Summary
- Extend `enerzyme listen` with `-cp` and the same hybrid YAML keys as simulate (`Server.external_calculator`, `internal_calculator_weight`, optional `uncertainty_calculator`).
- Route server inference through `ASECalculator` so internal MLFF and external ASE calculators can be blended.
- When `internal_calculator_weight` is 0 and UDD is absent, skip Modelhub/checkpoints entirely so listen can run as a pure external-calculator shell with only `-c` + `-cp`.

## Test plan
- [x] Mock external calculator: `FFListen` shell mode registers `model_key=external` with `model is None` and returns correctly unit-converted E/Fa
- [x] Shell mode without `-cp` raises a clear `ValueError`
- [x] Manual: `enerzyme listen -c enerzyme/config/server_uma.yaml -o out/ -b 0.0.0.0:5000 -cp /path/to/uma.py` then `enerzyme request ...`
- [x] Regression: existing internal-only listen with `-m` / `-mc` still serves ORCA `.engrad`