### PR TITLE
Harden ASE LMDB field maps and property discovery

### DIFF
--- a/docs/user_guide/data/datahub_reference.rst
+++ b/docs/user_guide/data/datahub_reference.rst
@@ -68,6 +68,14 @@ Keys are **standard Enerzyme names**; values are attribute names in your file. U
 
 :code:`N` can be omitted and inferred from :code:`Za`. :code:`Q` defaults to 0 if missing.
 
+For :code:`data_format: aselmdb`, ASE LMDB already exposes standard names
+(:code:`Ra`, :code:`Za`, :code:`E`, :code:`Fa`, …). Use **identity** maps
+(:code:`E: null` / :code:`E: E`), not pickle aliases such as :code:`E: energy`
+or :code:`Ra: coord` — non-identity maps for those fixed fields raise
+:code:`ValueError`. Declared fields that are missing from the source raise
+:code:`KeyError` instead of being skipped silently. Custom keys stored in ASE
+row :code:`data` may still use non-identity maps.
+
 Custom fields
 -------------
 

--- a/docs/user_guide/data/datahub_reference.rst
+++ b/docs/user_guide/data/datahub_reference.rst
@@ -72,9 +72,11 @@ For :code:`data_format: aselmdb`, ASE LMDB already exposes standard names
 (:code:`Ra`, :code:`Za`, :code:`E`, :code:`Fa`, …). Use **identity** maps
 (:code:`E: null` / :code:`E: E`), not pickle aliases such as :code:`E: energy`
 or :code:`Ra: coord` — non-identity maps for those fixed fields raise
-:code:`ValueError`. Declared fields that are missing from the source raise
-:code:`KeyError` instead of being skipped silently. Custom keys stored in ASE
-row :code:`data` may still use non-identity maps.
+:code:`ValueError`. Declared calculator fields (:code:`E`, :code:`Fa`, :code:`M2`, …)
+are registered even when the first DB row lacks them; annotate also stores an
+:code:`enerzyme_properties` schema in ASE DB metadata. Declared fields that are
+still missing from the source raise at load time instead of being skipped silently.
+Custom keys stored in ASE row :code:`data` may still use non-identity maps.
 
 Custom fields
 -------------

--- a/docs/user_guide/data/dataset_formats.rst
+++ b/docs/user_guide/data/dataset_formats.rst
@@ -51,6 +51,11 @@ ASE calculator / info key names (:code:`energy`, :code:`dipole`, :code:`charge`,
 (:code:`E: null`, :code:`Fa: null`, …). Pickle-style aliases (:code:`E: energy`,
 :code:`Ra: coord`) are rejected.
 
+Property discovery does **not** rely on the first row alone: :code:`enerzyme annotate`
+writes an :code:`enerzyme_properties` metadata schema, and Datahub also registers any
+calculator field declared in :code:`features` / :code:`targets`. First-row probing remains
+a fallback for legacy databases without schema.
+
 :code:`enerzyme annotate` writes this format by default via :code:`QMDriver.output_file` (see :doc:`/user_guide/workflows/qm_annotation`). Enerzymette's outer AL loop still merges :code:`fragments.pkl` today — keep :code:`pickle_name: fragments.pkl` for those campaigns, or train directly from :code:`.aselmdb` outside Enerzymette.
 
 TeraChem to pickle

--- a/docs/user_guide/data/dataset_formats.rst
+++ b/docs/user_guide/data/dataset_formats.rst
@@ -47,7 +47,9 @@ Lazy property accessors map ASE calculator results and :code:`atoms.info` / row 
 - :code:`Qa`, :code:`Sa` — charges / magnetic moments when present on the calculator
 - :code:`Q`, :code:`S` — from ASE info ``charge`` / ``spin`` (fairchem-style; :code:`S = spin - 1`)
 
-ASE calculator / info key names (:code:`energy`, :code:`dipole`, :code:`charge`, …) stay on the :code:`Atoms` object; Datahub only exposes the standard Enerzyme names above.
+ASE calculator / info key names (:code:`energy`, :code:`dipole`, :code:`charge`, …) stay on the :code:`Atoms` object; Datahub only exposes the standard Enerzyme names above. Training YAML must therefore use **identity** feature/target maps
+(:code:`E: null`, :code:`Fa: null`, …). Pickle-style aliases (:code:`E: energy`,
+:code:`Ra: coord`) are rejected.
 
 :code:`enerzyme annotate` writes this format by default via :code:`QMDriver.output_file` (see :doc:`/user_guide/workflows/qm_annotation`). Enerzymette's outer AL loop still merges :code:`fragments.pkl` today — keep :code:`pickle_name: fragments.pkl` for those campaigns, or train directly from :code:`.aselmdb` outside Enerzymette.
 

--- a/enerzyme/data/datahub.py
+++ b/enerzyme/data/datahub.py
@@ -27,12 +27,66 @@ ASE_PROPERTY_METHODS: Dict[str, Callable[[Atoms], Any]] = {
     "M2": lambda atoms: atoms.get_dipole_moment(),
 }
 
+# ASE SinglePointCalculator.results keys → standard Enerzyme names.
+_ASE_RESULTS_KEY_TO_STANDARD = {
+    "energy": "E",
+    "forces": "Fa",
+    "dipole": "M2",
+    "charges": "Qa",
+    "magmoms": "Sa",
+}
+
+# Written by annotate into ase.db metadata; preferred over first-row probing.
+ASELMDB_METADATA_PROPERTIES_KEY = "enerzyme_properties"
+
 # ASE info keys that are remapped to standard names (not exposed as Datahub keys).
 _ASE_INFO_STANDARD_KEYS = frozenset({"charge", "spin"})
 
+# Always available geometry / charge fields (no calculator required).
+_ASELMDB_GEOMETRY_KEYS = frozenset({"Ra", "Za", "N", "Q", "S"})
+
 # ASELMDBDataset exposes these under standard Enerzyme names only (not pickle aliases
 # like energy/coord/grad). Custom row-data fields may still use non-identity maps.
-_ASELMDB_FIXED_KEYS = frozenset({"Ra", "Za", "N", "Q", "S"}) | frozenset(ASE_PROPERTY_METHODS)
+_ASELMDB_FIXED_KEYS = _ASELMDB_GEOMETRY_KEYS | frozenset(ASE_PROPERTY_METHODS)
+
+
+def _probe_calculator_properties(atoms: Atoms) -> set:
+    """Discover calculator-backed fields from ``calc.results`` (fallback: accessors)."""
+    found: set = set()
+    if atoms.calc is None:
+        return found
+    results = getattr(atoms.calc, "results", None) or {}
+    for ase_key, std_key in _ASE_RESULTS_KEY_TO_STANDARD.items():
+        if ase_key in results:
+            found.add(std_key)
+    for prop, method in ASE_PROPERTY_METHODS.items():
+        if prop in found:
+            continue
+        try:
+            method(atoms)
+        except Exception as e:
+            logger.warning(f"Failed to get {prop} directly from calculator: {e}")
+        else:
+            found.add(prop)
+    return found
+
+
+def _read_aselmdb_schema_properties(dbs) -> set:
+    """Union ``enerzyme_properties`` metadata across connected ASE databases."""
+    schema: set = set()
+    for db in dbs:
+        try:
+            meta = dict(getattr(db, "metadata", None) or {})
+        except Exception as e:
+            logger.warning(f"Failed to read ASE DB metadata: {e}")
+            continue
+        props = meta.get(ASELMDB_METADATA_PROPERTIES_KEY)
+        if not props:
+            continue
+        if isinstance(props, str):
+            props = [props]
+        schema.update(str(p) for p in props)
+    return schema
 
 
 def load_from_pickle(data_path=str):
@@ -116,6 +170,7 @@ class ASELMDBDataset:
         connect_args: Dict[str, Any]=dict(),
         select_args: Dict[str, Any]=dict(),
         transforms: Optional[Dict[str, Any]]=None,
+        declared_properties: Optional[Iterable[str]]=None,
     ):
         if transforms and transforms.get("energy_unit_conversion"):
             logger.warning(
@@ -157,6 +212,8 @@ class ASELMDBDataset:
                 self.db_ids.append([row.id for row in db.select(**select_args)])
         self.id_lens = [len(ids) for ids in self.db_ids]
         self._id_len_segments = np.cumsum(self.id_lens).tolist()
+        if not self._id_len_segments or self._id_len_segments[-1] == 0:
+            raise ValueError(f"No rows found in ASE LMDB path(s): {data_path}")
 
         first_db = self.dbs[0]
         try:
@@ -164,17 +221,13 @@ class ASELMDBDataset:
             first_atoms = first_row.toatoms()
         except Exception as e:
             raise ValueError(f"Failed to get atoms from {first_db}: {e}")
-        
-        properties_from_calculator = set()
-        if first_atoms.calc is not None:
-            for prop, method in ASE_PROPERTY_METHODS.items():
-                try:
-                    method(first_atoms)
-                except Exception as e:
-                    logger.warning(f"Failed to get {prop} directly from calculator: {e}")
-                else:
-                    properties_from_calculator.add(prop)
-        
+
+        # Discovery priority: DB schema metadata → Datahub-declared fields → first-row probe.
+        # First-row probing alone misses properties present only on later frames.
+        properties_from_schema = _read_aselmdb_schema_properties(self.dbs)
+        declared = {str(p) for p in (declared_properties or [])}
+        properties_from_calculator = _probe_calculator_properties(first_atoms)
+
         self.properties_from_info = set()
         # ASE may store data as null / omit it; AtomsRow.data then returns None
         # or raises when wrapping None in FancyDict.
@@ -189,14 +242,36 @@ class ASELMDBDataset:
                 if isinstance(v, float) or isinstance(v, int) or isinstance(v, np.ndarray):
                     self.properties_from_info.add(k)
 
-        self.unique_properties_from_calculator = properties_from_calculator - self.properties_from_info
-        overlapped_properties = properties_from_calculator & self.properties_from_info
+        schema_calc = properties_from_schema & set(ASE_PROPERTY_METHODS)
+        schema_info = properties_from_schema - _ASELMDB_FIXED_KEYS
+        declared_calc = declared & set(ASE_PROPERTY_METHODS)
+
+        calculator_backed = properties_from_calculator | schema_calc | declared_calc
+        self.properties_from_info |= schema_info
+
+        if (schema_calc or declared_calc) and (
+            (schema_calc | declared_calc) - properties_from_calculator
+        ):
+            missing_on_first = (schema_calc | declared_calc) - properties_from_calculator
+            logger.info(
+                "Calculator fields not on the first ASE row but registered via "
+                f"schema/declared maps: {sorted(missing_on_first)}"
+            )
+
+        self.unique_properties_from_calculator = calculator_backed - self.properties_from_info
+        overlapped_properties = calculator_backed & self.properties_from_info
         # Q / S always available via atoms.info defaults (charge=0, spin multiplicity=1 → S=0)
-        self._all_properties = self.unique_properties_from_calculator | self.properties_from_info | {
-            "Ra", "Za", "N", "Q", "S"
-        }
+        self._all_properties = (
+            self.unique_properties_from_calculator
+            | self.properties_from_info
+            | _ASELMDB_GEOMETRY_KEYS
+        )
         if overlapped_properties:
             logger.warning(f"Property {overlapped_properties} found in calculator will be overwritten by info")
+        if properties_from_schema:
+            logger.info(f"Properties from ASE DB schema: {sorted(properties_from_schema)}")
+        if declared:
+            logger.info(f"Properties declared by Datahub: {sorted(declared)}")
         logger.info(f"Properties from calculator: {self.unique_properties_from_calculator}")
         logger.info(f"Properties from info: {self.properties_from_info}")
 
@@ -214,7 +289,7 @@ class ASELMDBDataset:
             get_property_method = lambda atoms: atoms.info.get("charge", 0)
         elif k == "S":
             get_property_method = lambda atoms: atoms.info.get("spin", 1) - 1
-        elif k in ASE_PROPERTY_METHODS.keys() and k in self.unique_properties_from_calculator:
+        elif k in ASE_PROPERTY_METHODS and k in self.unique_properties_from_calculator:
             if k in {"E", "Fa"}:
                 get_property_method = lambda atoms, p=k: ASE_PROPERTY_METHODS[p](atoms) * self.energy_unit_conversion_factor
             else:
@@ -516,6 +591,7 @@ class SingleDataHub:
                 connect_args=self.connect_args,
                 select_args=self.select_args,
                 transforms=aselmdb_transforms or None,
+                declared_properties=self.data_types.keys(),
             )
             # Unit conversion is already applied in ASELMDBDataset; drop the transform so it is not applied twice.
             if aselmdb_transforms.get("energy_unit_conversion"):

--- a/enerzyme/data/datahub.py
+++ b/enerzyme/data/datahub.py
@@ -30,6 +30,10 @@ ASE_PROPERTY_METHODS: Dict[str, Callable[[Atoms], Any]] = {
 # ASE info keys that are remapped to standard names (not exposed as Datahub keys).
 _ASE_INFO_STANDARD_KEYS = frozenset({"charge", "spin"})
 
+# ASELMDBDataset exposes these under standard Enerzyme names only (not pickle aliases
+# like energy/coord/grad). Custom row-data fields may still use non-identity maps.
+_ASELMDB_FIXED_KEYS = frozenset({"Ra", "Za", "N", "Q", "S"}) | frozenset(ASE_PROPERTY_METHODS)
+
 
 def load_from_pickle(data_path=str):
     with open(data_path, "rb") as f:
@@ -412,6 +416,37 @@ class SingleDataHub:
         else:
             return value_array
 
+    def _validate_aselmdb_field_maps(self) -> None:
+        """Reject pickle-style aliases for fixed ASE LMDB standard names."""
+        bad = {
+            k: src for k, src in self.data_types.items()
+            if k in _ASELMDB_FIXED_KEYS and src != k
+        }
+        if not bad:
+            return
+        examples = ", ".join(f"{k}: {src}" for k, src in sorted(bad.items()))
+        raise ValueError(
+            "data_format=aselmdb exposes standard Enerzyme names only "
+            f"(Ra/Za/N/Q/S and calculator fields {sorted(ASE_PROPERTY_METHODS)}). "
+            "Use identity maps (e.g. E: null or E: E), not pickle-style aliases "
+            f"such as E: energy / Ra: coord. Invalid maps: {{{examples}}}. "
+            "Custom row-data fields may still use non-identity maps."
+        )
+
+    def _missing_source_error(self, k: str, raw_data: Dict) -> KeyError:
+        src = self.data_types[k]
+        available = sorted(raw_data.keys()) if hasattr(raw_data, "keys") else []
+        hint = ""
+        if self.data_format == "aselmdb" and k in _ASELMDB_FIXED_KEYS and src != k:
+            hint = (
+                f" For data_format=aselmdb use an identity map "
+                f"(e.g. {k}: null or {k}: {k}), not a pickle-style alias."
+            )
+        return KeyError(
+            f"Requested field '{k}' (source '{src}') not found in raw data "
+            f"(available: {available}).{hint}"
+        )
+
     def _load_molecular_data(self, k: str, raw_data: Dict) -> None:
         if self.data_types[k] in raw_data.keys():
             values = raw_data[self.data_types[k]]
@@ -421,7 +456,7 @@ class SingleDataHub:
                 self.data.create_dataset(k, data=self._compress(k, values))
             else:
                 raise IndexError(f"Length of '{k}' should be n_datapoint or 1")
-        elif self.data_types[k + "a"] in raw_data.keys():
+        elif (k + "a") in self.data_types and self.data_types[k + "a"] in raw_data.keys():
             self._load_atomic_data(k + "a", raw_data)
             # reduce atomic property into molecular property, mainly for Qa into Q
             logger.info(f"Molecular property {k} are reduced from atomic property {k + 'a'} ({self.data_types[k + 'a']})")
@@ -431,30 +466,46 @@ class SingleDataHub:
                 values = [sum(self.data[k + "a"][i][:self.data["N"][i % len(self.data["N"])]]) for i in tqdm(range(self.n_datapoint))]
             # don't compress summation of atomic property
             self.data.create_dataset(k, data=np.array(values))
+        else:
+            raise self._missing_source_error(k, raw_data)
 
     def _load_atomic_data(self, k: str, raw_data: Dict) -> None:
         if k in self.data:
             return
-        values = raw_data[self.data_types[k]]
-        v0 = np.array(values[0])
+        src = self.data_types[k]
+        if src not in raw_data.keys():
+            raise self._missing_source_error(k, raw_data)
+        values = raw_data[src]
+        sample = values[0]
+        if sample is None:
+            raise ValueError(
+                f"Atomic field '{k}' (source '{src}') returned None for the first "
+                f"datapoint; check the feature/target map and dataset contents."
+            )
+        v0 = np.array(sample)
         if len(values) == self.n_datapoint:
             # for a datapoint, the shape of this property is (N, a, b, ...)
             # for the whole dataset, the shape of this property is (n_datapoint, max_N, a, b, ...)
             self.data.create_dataset(k, shape=(self.n_datapoint, self.max_N, *v0.shape[1:]), dtype=v0.dtype)
-            logger.info(f"Storing atomic data {k} ({self.data_types[k]})")
+            logger.info(f"Storing atomic data {k} ({src})")
             for i, v in tqdm(enumerate(values), total=self.n_datapoint):
+                if v is None:
+                    raise ValueError(
+                        f"Atomic field '{k}' (source '{src}') returned None at index {i}."
+                    )
                 self.data[k][i,:len(v)] = v
 
         elif len(values) == 1:
             self.data.create_dataset(k, data=self._expand(k, values))
         else:
-            raise IndexError(f"Length of {k} ({self.data_types[k]}) should be n_datapoint")
+            raise IndexError(f"Length of {k} ({src}) should be n_datapoint")
 
     def _init_data(self) -> None:
         suffix = self.data_path.split(".")[-1]
         # aselmdb accepts a file, directory of DB files, or glob; ASELMDBDataset validates the path
         if self.data_format == "aselmdb" or suffix == "aselmdb":
             self.data_format = "aselmdb"
+            self._validate_aselmdb_field_maps()
             aselmdb_transforms = {}
             if self.preprocessings:
                 aselmdb_transforms.update(self.preprocessings)

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -26,6 +26,9 @@ QM_CALCULATED_TO_ASE_PROPERTY = {
     "Sa": "magmoms",
 }
 
+# Geometry / charge fields always present on ASE LMDB rows written by annotate.
+_ASELMDB_SCHEMA_GEOMETRY = ("Ra", "Za", "N", "Q", "S")
+
 # Optional annotate pickle rename: standard Enerzyme name → custom key in the .pkl dict.
 # Values stay standard (E/Fa in Ha / Ha·Å⁻¹, M2 in e·Å, Za atomic numbers, Q, S=2S+1−1).
 # Enerzymette AL historically expects the names below (and Fa stored as ∇E under ``grad``).
@@ -210,6 +213,27 @@ class QMDriver(ABC):
             else:
                 raise FileNotFoundError(f"Molden file {molden_file} not found")
 
+    def aselmdb_schema_properties(self) -> List[str]:
+        """Standard names written into ASE LMDB metadata for Datahub discovery."""
+        # Geometry/charge always; E/Fa/M2 from successful QM (Qa/Sa only if a driver adds them).
+        return list(_ASELMDB_SCHEMA_GEOMETRY) + ["E", "Fa", "M2"]
+
+    def _ensure_aselmdb_schema(self) -> None:
+        """Persist property schema so readers need not rely on the first row alone."""
+        from ..data.datahub import ASELMDB_METADATA_PROPERTIES_KEY
+
+        props = self.aselmdb_schema_properties()
+        db = connect(self.output_path, **self.default_connect_args)
+        meta = dict(db.metadata or {})
+        if meta.get(ASELMDB_METADATA_PROPERTIES_KEY) == props:
+            return
+        meta[ASELMDB_METADATA_PROPERTIES_KEY] = props
+        db.metadata = meta
+        logger.info(
+            f"Wrote ASE LMDB schema {ASELMDB_METADATA_PROPERTIES_KEY}={props} "
+            f"to {self.output_path}"
+        )
+
     def _run_qm(self, atoms: Atoms) -> Optional[Dict[str, Any]]:
         index = atoms.info["index"]
         tmp_dir = Path(str(self.tmp_dir_base) + f".{index}")
@@ -343,6 +367,7 @@ class QMDriver(ABC):
             self.supplier = supplier
 
     def _run_aselmdb(self) -> None:
+        self._ensure_aselmdb_schema()
         if self.n_processes == 1:
             for atoms in tqdm(self.supplier.suppl(), desc="Running QM", dynamic_ncols=True, leave=False, position=0):
                 self.single_run_aselmdb(atoms)

--- a/example/L3-COMT-aselmdb-smoke/scripts/pickle_to_aselmdb.py
+++ b/example/L3-COMT-aselmdb-smoke/scripts/pickle_to_aselmdb.py
@@ -77,6 +77,14 @@ def convert(pickle_path: Path, out_path: Path, limit: int | None = None) -> int:
             atoms.calc = SinglePointCalculator(atoms, **calc_kwargs)
             db.write(atoms, data=info, index=info["index"])
             n += 1
+        # Prefer schema over first-row probing when Datahub loads the DB.
+        from enerzyme.data.datahub import ASELMDB_METADATA_PROPERTIES_KEY
+
+        meta = dict(db.metadata or {})
+        meta[ASELMDB_METADATA_PROPERTIES_KEY] = [
+            "Ra", "Za", "N", "Q", "S", "E", "Fa", "M2",
+        ]
+        db.metadata = meta
     return n
 
 

--- a/test/test_aselmdb.py
+++ b/test/test_aselmdb.py
@@ -107,6 +107,43 @@ def test_singledatahub_loads_m2_from_aselmdb(tmp_path):
     np.testing.assert_allclose(hub.data["M2"][0], dipole)
 
 
+def test_singledatahub_rejects_pickle_style_aselmdb_maps(tmp_path):
+    """Pickle aliases (E: energy, Ra: coord) must fail loudly for aselmdb."""
+    db_path = tmp_path / "toy.aselmdb"
+    _write_toy_aselmdb(db_path)
+
+    with pytest.raises(ValueError, match="identity maps"):
+        SingleDataHub(
+            dump_dir=str(tmp_path / "out"),
+            data_path=str(db_path),
+            data_format="aselmdb",
+            preload=False,
+            features={"Ra": "coord", "Za": "atom_type", "N": "N", "Q": "total_chrg"},
+            targets={"E": "energy", "Fa": "grad"},
+            neighbor_list="",
+            compressed=False,
+        )
+
+
+def test_singledatahub_raises_on_missing_molecular_source(tmp_path):
+    """Declared molecular fields absent from raw data must not be skipped silently."""
+    db_path = tmp_path / "toy.aselmdb"
+    _write_toy_aselmdb(db_path)
+
+    with pytest.raises(KeyError, match="Requested field 'M2'"):
+        SingleDataHub(
+            dump_dir=str(tmp_path / "out"),
+            data_path=str(db_path),
+            data_format="aselmdb",
+            preload=False,
+            features={"Ra": "Ra", "Za": "Za", "N": "N", "Q": "Q"},
+            # Toy DB has no dipole → M2 not in ASELMDBDataset.keys()
+            targets={"E": "E", "Fa": "Fa", "M2": "M2"},
+            neighbor_list="",
+            compressed=False,
+        )
+
+
 @pytest.mark.parametrize(
     "path_kind",
     ["directory", "glob"],

--- a/test/test_aselmdb.py
+++ b/test/test_aselmdb.py
@@ -61,6 +61,46 @@ def test_aselmdb_dataset_loads_dipole_as_m2(tmp_path):
     np.testing.assert_allclose(ds["M2"][0], dipole)
 
 
+def test_aselmdb_declared_m2_when_first_row_lacks_dipole(tmp_path):
+    """Declared / schema registration must not depend on the first row alone."""
+    from enerzyme.data.datahub import ASELMDB_METADATA_PROPERTIES_KEY
+
+    db_path = tmp_path / "sparse_dipole.aselmdb"
+    dipole = np.array([0.11, -0.22, 0.33])
+    _write_toy_aselmdb(db_path, energy_ev=-1.0, index=0)  # no dipole
+    atoms = Atoms("H2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]])
+    atoms.calc = SinglePointCalculator(
+        atoms,
+        energy=-2.0,
+        forces=np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0]]),
+        dipole=dipole,
+    )
+    with connect(str(db_path)) as db:
+        db.write(atoms, data={"charge": 0, "spin": 1, "index": 1}, index=1)
+
+    # Without help, first-row probe misses M2.
+    ds_probe = ASELMDBDataset(str(db_path), new_energy_unit="Ha")
+    assert "M2" not in ds_probe
+
+    # Declared Datahub targets register M2 even when row 0 lacks dipole.
+    ds_declared = ASELMDBDataset(
+        str(db_path),
+        new_energy_unit="Ha",
+        declared_properties=["E", "Fa", "M2"],
+    )
+    assert "M2" in ds_declared
+    np.testing.assert_allclose(ds_declared["M2"][1], dipole)
+
+    # Writer schema likewise registers M2 without probing row 0.
+    with connect(str(db_path)) as db:
+        meta = dict(db.metadata or {})
+        meta[ASELMDB_METADATA_PROPERTIES_KEY] = ["Ra", "Za", "N", "Q", "S", "E", "Fa", "M2"]
+        db.metadata = meta
+    ds_schema = ASELMDBDataset(str(db_path), new_energy_unit="Ha")
+    assert "M2" in ds_schema
+    np.testing.assert_allclose(ds_schema["M2"][1], dipole)
+
+
 def test_aselmdb_dataset_handles_none_row_data(tmp_path, monkeypatch):
     """Rows with data=None / null must still expose calculator-backed E/Fa."""
     from ase_db_backends.aselmdb import LMDBDatabase
@@ -126,19 +166,37 @@ def test_singledatahub_rejects_pickle_style_aselmdb_maps(tmp_path):
 
 
 def test_singledatahub_raises_on_missing_molecular_source(tmp_path):
-    """Declared molecular fields absent from raw data must not be skipped silently."""
+    """Declared molecular fields that no row can supply must fail while loading."""
     db_path = tmp_path / "toy.aselmdb"
-    _write_toy_aselmdb(db_path)
+    _write_toy_aselmdb(db_path)  # no dipole on any row
 
-    with pytest.raises(KeyError, match="Requested field 'M2'"):
+    with pytest.raises(Exception, match=r"dipole"):
         SingleDataHub(
             dump_dir=str(tmp_path / "out"),
             data_path=str(db_path),
             data_format="aselmdb",
             preload=False,
             features={"Ra": "Ra", "Za": "Za", "N": "N", "Q": "Q"},
-            # Toy DB has no dipole → M2 not in ASELMDBDataset.keys()
+            # Declared M2 is registered, then get_dipole_moment fails on the toy row.
             targets={"E": "E", "Fa": "Fa", "M2": "M2"},
+            neighbor_list="",
+            compressed=False,
+        )
+
+
+def test_singledatahub_raises_on_unknown_custom_source(tmp_path):
+    """Custom targets absent from row data still raise KeyError (not silent skip)."""
+    db_path = tmp_path / "toy.aselmdb"
+    _write_toy_aselmdb(db_path)
+
+    with pytest.raises(KeyError, match="Requested field 'foo'"):
+        SingleDataHub(
+            dump_dir=str(tmp_path / "out"),
+            data_path=str(db_path),
+            data_format="aselmdb",
+            preload=False,
+            features={"Ra": "Ra", "Za": "Za", "N": "N", "Q": "Q"},
+            targets={"E": "E", "Fa": "Fa", "foo": "foo"},
             neighbor_list="",
             compressed=False,
         )

--- a/test/test_aselmdb_al_smoke.py
+++ b/test/test_aselmdb_al_smoke.py
@@ -158,6 +158,8 @@ def test_mock_qm_driver_writes_aselmdb(tmp_path: Path):
         atoms = row.toatoms()
         assert "dipole" in atoms.calc.results
         np.testing.assert_allclose(atoms.get_dipole_moment(), [0.1, 0.2, 0.3])
+        from enerzyme.data.datahub import ASELMDB_METADATA_PROPERTIES_KEY
+        assert "M2" in db.metadata.get(ASELMDB_METADATA_PROPERTIES_KEY, [])
 
     ds = ASELMDBDataset(str(db_files[0]), new_energy_unit="Ha")
     assert "M2" in ds


### PR DESCRIPTION
## Summary
- Require identity feature/target maps for fixed ASE LMDB fields (`Ra`/`Za`/`E`/`Fa`/…); pickle aliases like `E: energy` now raise `ValueError`.
- Stop silently skipping missing molecular sources and harden atomic loads against `None`/absent aliases (`KeyError`/`ValueError`).
- Fix first-row-only property discovery: register calculator fields from annotate `enerzyme_properties` metadata and Datahub-declared `features`/`targets`, with first-row probing as fallback (addresses Bugbot on #80).
- Document the aselmdb identity-map / schema contract; add regression tests.

## Test plan
- [x] `pytest test/test_aselmdb.py test/test_aselmdb_al_smoke.py -q` in `enerzyme-dev` (31 passed)
- [ ] Optionally `enerzyme collect` on `example/L3-COMT-aselmdb-smoke/config/train_aselmdb.yaml`
- [ ] Confirm a config with `E: energy` / `Ra: coord` fails fast under `data_format: aselmdb`
- [ ] Confirm `M2` still loads when the first ASE row lacks dipole but later rows / schema / declared targets include it