### PR TITLE
SimpleReadout equivariant 0e + EquiformerGraphAttentionReadout

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -200,8 +200,9 @@ Adding an internal architecture
 6. Document in :doc:`/user_guide/models/architecture_catalog`
 
 Recent internal example: :code:`Equiformer` under :code:`enerzyme/models/equiformer/`
-(irreps atom embedding as a pre-core layer; Core emits :code:`atom_feature` by default;
-shared :code:`SimpleReadout` / physics layers after the Core).
+(irreps atom embedding as a pre-core layer; Core emits full-irreps :code:`atom_feature`
+with :code:`feature_irreps` by default; shared :code:`SimpleReadout` extracts 0e then MLP,
+or optional :code:`EquiformerGraphAttentionReadout` / physics layers after the Core).
 
 Adding an external wrapper
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,6 +272,7 @@ Tests live in :code:`test/`:
 - :code:`test_spookynet.py` — SpookyNet layer and forward tests
 - :code:`test_physnet.py` — PhysNet parity against reference TensorFlow implementation (heavy optional stack)
 - :code:`test_equiformer.py` — Equiformer forward smoke, feature mode, SO(3) energy/force checks
+- :code:`test_equiformer_readout.py` — 0e extract, :code:`two_layer` SimpleReadout, GraphAttention readout
 - :code:`test_equiformer_parity_*.py` — numerical parity vs vendored upstream Equiformer (ops / Core latent / direct E·F / grads; no training loop)
 - :code:`test_scatter_speed.py` — performance-oriented scatter checks
 

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -273,7 +273,10 @@ Tests live in :code:`test/`:
 - :code:`test_physnet.py` — PhysNet parity against reference TensorFlow implementation (heavy optional stack)
 - :code:`test_equiformer.py` — Equiformer forward smoke, feature mode, SO(3) energy/force checks
 - :code:`test_equiformer_readout.py` — 0e extract, :code:`two_layer` SimpleReadout, GraphAttention readout
-- :code:`test_equiformer_parity_*.py` — numerical parity vs vendored upstream Equiformer (ops / Core latent / direct E·F / grads; no training loop)
+- :code:`test_equiformer_parity_*.py` — numerical parity vs vendored upstream Equiformer
+  (ops / Core latent incl. feature ``get_output`` / direct E·F / grads /
+  feature-mode + GraphAttention readout; no training loop; production
+  :code:`SimpleReadout` Dense MLP is not LinearRS-parity)
 - :code:`test_scatter_speed.py` — performance-oriented scatter checks
 
 Suggested commands

--- a/docs/user_guide/models/architecture_catalog.rst
+++ b/docs/user_guide/models/architecture_catalog.rst
@@ -64,9 +64,12 @@ Selection guidelines
 **Maximum accuracy on diverse geometries**
     MACE, NequIP, or Equiformer — equivariant message passing; tune cutoff and depth.
     Equiformer uses SO(3) graph attention (default MD17-style stack with ``ExpNormalSmearing``
-    and :code:`output_mode: feature`); prefer smaller irreps / fewer layers for enzyme-scale
-    clusters. Charge/dipole use shared readouts outside the Core. Numerical fidelity against
-    the official Equiformer MD17 path is covered by :code:`test/test_equiformer_parity_*.py`
+    and :code:`output_mode: feature` emitting full irreps plus :code:`feature_irreps`;
+    production default is :code:`SimpleReadout` with :code:`head_type: two_layer` after 0e
+    extract, optional :code:`EquiformerGraphAttentionReadout`); prefer smaller irreps /
+    fewer layers for enzyme-scale clusters. Charge/dipole use shared readouts outside the
+    Core. Numerical fidelity against the official Equiformer MD17 path is covered by
+    :code:`test/test_equiformer_parity_*.py`
     (operator / latent / direct E·F / gradient checks — not the production SimpleReadout stack).
 
 **Active learning with force variance**

--- a/docs/user_guide/models/layer_stack.rst
+++ b/docs/user_guide/models/layer_stack.rst
@@ -30,6 +30,8 @@ From :code:`enerzyme/models/layers/`:
     :code:`SimpleReadout` — per-atom MLP over scalar features. With equivariant Cores
     that set :code:`feature_irreps`, it extracts even-scalar (:code:`0e`) channels first,
     then applies :code:`dense` / :code:`residual_*` / :code:`two_layer` heads.
+    Use :code:`head_type: equiformer_linear_rs` for the official Equiformer MD17 scalar
+    energy MLP (:code:`LinearRS` → :code:`normalize2mom(SiLU)` → :code:`LinearRS`).
     :code:`EquiformerGraphAttentionReadout` — separate GraphAttention head over full
     irreps + graph edges (not mixed into SimpleReadout); use when you want an
     attention-style multi-field atomic scalar head.

--- a/docs/user_guide/models/layer_stack.rst
+++ b/docs/user_guide/models/layer_stack.rst
@@ -26,6 +26,14 @@ From :code:`enerzyme/models/layers/`:
 **Output**
     :code:`EnergyReduce`, :code:`Force`, :code:`ShallowEnsembleReduce`
 
+**Readouts**
+    :code:`SimpleReadout` — per-atom MLP over scalar features. With equivariant Cores
+    that set :code:`feature_irreps`, it extracts even-scalar (:code:`0e`) channels first,
+    then applies :code:`dense` / :code:`residual_*` / :code:`two_layer` heads.
+    :code:`EquiformerGraphAttentionReadout` — separate GraphAttention head over full
+    irreps + graph edges (not mixed into SimpleReadout); use when you want an
+    attention-style multi-field atomic scalar head.
+
 Typical charge-aware stack
 --------------------------
 
@@ -92,6 +100,16 @@ UMA and modular readouts
 ------------------------
 
 With :code:`architecture: uma_qs`, the Core returns atom-level embeddings; attach :code:`SimpleReadout` / :code:`HierachicalReadout` and optional :code:`SpinConservation` in the Modelhub :code:`layers` list rather than embedding prediction heads inside the Core.
+
+Equivariant feature contract and Equiformer readouts
+----------------------------------------------------
+
+Equivariant Cores may emit a flat irreps tensor as :code:`atom_feature` and advertise
+layout via :code:`feature_irreps` (e.g. :code:`"64x0e+32x1e"`). :code:`dim_feature_out` is the
+**0e channel count** used by scalar MLP readouts. :code:`SimpleReadout` extracts those
+0e channels (identity when :code:`feature_irreps` is absent). For a GraphAttention
+energy/charge head, swap in :code:`EquiformerGraphAttentionReadout` (see FF09 comments
+in :code:`train.yaml`).
 
 NSE readout layers
 ------------------

--- a/enerzyme/config/train.yaml
+++ b/enerzyme/config/train.yaml
@@ -685,13 +685,21 @@ Modelhub:
             fc_neurons: [64, 64]
             nonlinear_message: true
             output_mode: feature
+        # Default: SimpleReadout extracts 0e from equivariant atom_feature, then MLP.
+        # To use GraphAttention readout instead, replace SimpleReadout with:
+        # - name: EquiformerGraphAttentionReadout
+        #   params:
+        #     output_fields: [Ea, Qa]
+        #     irreps_head: "16x0e+8x1o+4x2e"
+        #     num_heads: 2
+        #     fc_neurons: [64, 64]
+        #     nonlinear_message: true
         - name: SimpleReadout
           params:
             output_fields:
               - Ea
               - Qa
-            head_type: residual_mlp
-            num_residual: 2
+            head_type: two_layer
             dim_embedding: 64
             activation_fn: swish
         - name: AtomicAffine

--- a/enerzyme/config/train.yaml
+++ b/enerzyme/config/train.yaml
@@ -686,6 +686,8 @@ Modelhub:
             nonlinear_message: true
             output_mode: feature
         # Default: SimpleReadout extracts 0e from equivariant atom_feature, then MLP.
+        # Official LinearRS + normalize2mom(SiLU) energy head (parity with MD17 MLP):
+        #   head_type: equiformer_linear_rs
         # To use GraphAttention readout instead, replace SimpleReadout with:
         # - name: EquiformerGraphAttentionReadout
         #   params:

--- a/enerzyme/models/equiformer/core.py
+++ b/enerzyme/models/equiformer/core.py
@@ -10,6 +10,7 @@ from e3nn import o3
 from torch import Tensor
 from torch.nn import Module, ModuleList
 
+from ..irreps_tools import extract_scalar_0e, scalar_0e_dim
 from ..layers._base_layer import BaseFFCore
 from ..layers.atom_embedding import BaseAtomEmbedding
 from ..layers.electrostatics import ChargeConservationLayer
@@ -74,8 +75,7 @@ DEFAULT_LAYER_PARAMS = [
         "name": "SimpleReadout",
         "params": {
             "output_fields": ["Ea", "Qa"],
-            "head_type": "residual_mlp",
-            "num_residual": 2,
+            "head_type": "two_layer",
             "dim_embedding": 64,
             "activation_fn": "swish",
         },
@@ -98,25 +98,6 @@ DEFAULT_LAYER_PARAMS = [
     {"name": "EnergyReduce"},
     {"name": "Force"},
 ]
-
-
-def _scalar_dim(irreps: o3.Irreps) -> int:
-    """Number of even scalar (0e) channels in an irreps."""
-    return sum(mul for mul, ir in irreps if ir.l == 0 and ir.p == 1)
-
-
-def _extract_scalars(node_features: Tensor, irreps: o3.Irreps) -> Tensor:
-    """Concatenate all 0e slices from an irreps feature tensor."""
-    pieces = []
-    offset = 0
-    for mul, ir in irreps:
-        width = mul * ir.dim
-        if ir.l == 0 and ir.p == 1:
-            pieces.append(node_features[:, offset : offset + width])
-        offset += width
-    if not pieces:
-        raise ValueError(f"No scalar (0e) channels in irreps {irreps}")
-    return torch.cat(pieces, dim=-1)
 
 
 class EquiformerCore(BaseFFCore):
@@ -184,7 +165,9 @@ class EquiformerCore(BaseFFCore):
         self.nonlinear_message = nonlinear_message
         self.use_attn_head = use_attn_head
         self.irreps_pre_attn = irreps_pre_attn
-        self.dim_feature_out = _scalar_dim(self.irreps_feature)
+        # Scalar readout contract: dim_feature_out is 0e channel count.
+        self.feature_irreps = str(self.irreps_feature)
+        self.dim_feature_out = scalar_0e_dim(self.irreps_feature)
 
         self.edge_deg_embed = EdgeDegreeEmbeddingNetwork(
             self.irreps_node_embedding,
@@ -375,7 +358,8 @@ class EquiformerCore(BaseFFCore):
         )
 
         if self.output_mode == "feature":
-            return {"atom_feature": _extract_scalars(node_features, self.irreps_feature)}
+            # Full irreps tensor; SimpleReadout extracts 0e via feature_irreps.
+            return {"atom_feature": node_features}
 
         if self.use_attn_head:
             outputs = self.head(

--- a/enerzyme/models/irreps_tools.py
+++ b/enerzyme/models/irreps_tools.py
@@ -1,12 +1,48 @@
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 from collections import namedtuple
 import torch
+from torch import Tensor
 import e3nn.o3 as o3
 from e3nn.util.jit import compile_mode
 from e3nn.o3 import Irreps
 
 _INPUT = namedtuple("_INPUT", "tensor, start, stop")
 _TP = namedtuple("_TP", "op, args")
+
+
+def scalar_0e_dim(irreps: Union[str, Irreps, None]) -> Optional[int]:
+    """Number of even scalar (0e) channels, or None if ``irreps`` is unset."""
+    if irreps is None:
+        return None
+    ir = Irreps(irreps)
+    return sum(mul for mul, irr in ir if irr.l == 0 and irr.p == 1)
+
+
+def extract_scalar_0e(
+    atom_feature: Tensor, irreps: Union[str, Irreps, None]
+) -> Tensor:
+    """Return even-scalar (0e) channels from a flat irreps feature.
+
+    If ``irreps`` is None, ``atom_feature`` is treated as already-scalar and
+    returned unchanged.
+    """
+    if irreps is None:
+        return atom_feature
+    ir = Irreps(irreps)
+    if atom_feature.shape[-1] != ir.dim:
+        raise ValueError(
+            f"atom_feature last dim {atom_feature.shape[-1]} != irreps.dim {ir.dim}"
+        )
+    pieces = []
+    offset = 0
+    for mul, irr in ir:
+        width = mul * irr.dim
+        if irr.l == 0 and irr.p == 1:
+            pieces.append(atom_feature[..., offset : offset + width])
+        offset += width
+    if not pieces:
+        raise ValueError(f"No scalar (0e) channels in irreps {ir}")
+    return torch.cat(pieces, dim=-1)
 
 
 def linear_out_irreps(irreps: Irreps, target_irreps: Irreps) -> Irreps:

--- a/enerzyme/models/layers/__init__.py
+++ b/enerzyme/models/layers/__init__.py
@@ -30,4 +30,5 @@ from .readout import (
     NSEReadout,
     HierachicalNSEReadout,
     VelocityReadout,
+    EquiformerGraphAttentionReadout,
 )

--- a/enerzyme/models/layers/readout.py
+++ b/enerzyme/models/layers/readout.py
@@ -8,6 +8,15 @@ from torch.nn import ModuleList, Module, Sequential
 from torch import Tensor
 
 
+HEAD_TYPE = Literal[
+    "dense",
+    "residual_layer",
+    "residual_mlp",
+    "two_layer",
+    "equiformer_linear_rs",
+]
+
+
 def _resolve_feature_irreps(built_layers: List[Module]) -> Optional[str]:
     """Find ``feature_irreps`` on the nearest prior Core (or any layer)."""
     for layer in reversed(built_layers):
@@ -22,7 +31,7 @@ class BaseReadout(BaseFFLayer):
         num_blocks: int,
         output_fields: Set[str],
         built_layers: List[Module],
-        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"],
+        head_type: HEAD_TYPE,
         dim_embedding: Optional[int]=None,
         shallow_ensemble_size: int=1,
         keep_feature: bool=False,
@@ -99,7 +108,7 @@ class BaseReadout(BaseFFLayer):
                 **self.head_params
             )
         elif self.head_type == "two_layer":
-            # Official-style energy MLP: Linear → SiLU/Swish → Linear.
+            # Dense MLP morphologically like the official energy head (not LinearRS).
             act = self.activation_fn if self.activation_fn is not None else "swish"
             return Sequential(
                 DenseLayer(
@@ -114,6 +123,26 @@ class BaseReadout(BaseFFLayer):
                     shallow_ensemble_size=self.shallow_ensemble_size,
                     **self.head_params,
                 ),
+            )
+        elif self.head_type == "equiformer_linear_rs":
+            # Official Equiformer MD17 scalar energy MLP:
+            # LinearRS → Activation(normalize2mom(SiLU)) → LinearRS.
+            if self.shallow_ensemble_size != 1:
+                raise ValueError(
+                    "head_type='equiformer_linear_rs' does not support "
+                    f"shallow_ensemble_size={self.shallow_ensemble_size}"
+                )
+            from e3nn import o3
+            from ..equiformer.attention import _RESCALE
+            from ..equiformer.fast_activation import Activation
+            from ..equiformer.tensor_product import LinearRS
+
+            ir_hid = o3.Irreps(f"{self.dim_feature_in}x0e")
+            ir_out = o3.Irreps(f"{self.dim_feature_out}x0e")
+            return Sequential(
+                LinearRS(ir_hid, ir_hid, rescale=_RESCALE),
+                Activation(ir_hid, acts=[torch.nn.SiLU()]),
+                LinearRS(ir_hid, ir_out, rescale=_RESCALE),
             )
         else:
             raise ValueError(f"Unknown head_type: {self.head_type}")
@@ -162,7 +191,7 @@ class SimpleReadout(BaseReadout):
     def __init__(self,
         output_fields: Set[str],
         built_layers: List[Module],
-        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"]="dense",
+        head_type: HEAD_TYPE="dense",
         dim_embedding: Optional[int]=None,
         shallow_ensemble_size: int=1,
         keep_feature: bool=False,
@@ -209,7 +238,7 @@ class NSEReadout(BaseReadout):
         self,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "residual_mlp",
+        head_type: HEAD_TYPE = "residual_mlp",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,
@@ -291,7 +320,7 @@ class HierachicalNSEReadout(BaseReadout):
         num_blocks: int,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "residual_mlp",
+        head_type: HEAD_TYPE = "residual_mlp",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,
@@ -355,7 +384,7 @@ class VelocityReadout(BaseReadout):
         self,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "dense",
+        head_type: HEAD_TYPE = "dense",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,

--- a/enerzyme/models/layers/readout.py
+++ b/enerzyme/models/layers/readout.py
@@ -1,34 +1,49 @@
-from abc import ABC
-from typing import Set, Literal, Dict, Any, Optional, List
+from typing import Set, Literal, Dict, Optional, List
 from . import BaseFFLayer
 from ..blocks.mlp import DenseLayer, ResidualMLP, ResidualLayer
 from ..activation import ACTIVATION_KEY_TYPE, ACTIVATION_PARAM_TYPE, POSITIVE_ACTIVATION_KEY_TYPE, get_positive_activation_fn
+from ..irreps_tools import extract_scalar_0e
 import torch
 from torch.nn import ModuleList, Module, Sequential
 from torch import Tensor
 
 
+def _resolve_feature_irreps(built_layers: List[Module]) -> Optional[str]:
+    """Find ``feature_irreps`` on the nearest prior Core (or any layer)."""
+    for layer in reversed(built_layers):
+        irreps = getattr(layer, "feature_irreps", None)
+        if irreps is not None:
+            return str(irreps)
+    return None
+
+
 class BaseReadout(BaseFFLayer):
-    def __init__(self, 
+    def __init__(self,
         num_blocks: int,
-        output_fields: Set[str], 
+        output_fields: Set[str],
         built_layers: List[Module],
-        head_type: Literal["dense", "residual_layer", "residual_mlp"],
+        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"],
         dim_embedding: Optional[int]=None,
-        shallow_ensemble_size: int=1, 
-        keep_feature: bool=False, 
+        shallow_ensemble_size: int=1,
+        keep_feature: bool=False,
         activation_fn: Optional[ACTIVATION_KEY_TYPE]=None,
         activation_params: ACTIVATION_PARAM_TYPE=dict(),
+        feature_irreps: Optional[str]=None,
         **head_params
     ) -> None:
         super().__init__(
-            input_fields=["atom_feature"], 
+            input_fields=["atom_feature"],
             output_fields=output_fields | {"atom_feature"} if keep_feature else output_fields
         )
         self.num_blocks = num_blocks
         self.shallow_ensemble_size = shallow_ensemble_size
         self.ordered_output_fields = sorted(list(output_fields))
         self.head_type = head_type
+        self.feature_irreps = (
+            feature_irreps
+            if feature_irreps is not None
+            else _resolve_feature_irreps(built_layers)
+        )
         if len(built_layers) > 0 and hasattr(built_layers[-1], "dim_feature_out"):
             self.dim_feature_in = built_layers[-1].dim_feature_out
         elif dim_embedding is not None:
@@ -40,10 +55,20 @@ class BaseReadout(BaseFFLayer):
         self.activation_params = activation_params
         self.head_params = head_params
 
+    def _scalar_atom_feature(self, atom_feature: Tensor) -> Tensor:
+        """Take last hierarchical block if needed, then extract 0e when equivariant."""
+        if atom_feature.ndim == 3:
+            atom_feature = atom_feature[:, :, -1]
+        elif atom_feature.ndim != 2:
+            raise ValueError(
+                f"atom_feature must be 2D or 3D, got shape {tuple(atom_feature.shape)}"
+            )
+        return extract_scalar_0e(atom_feature, self.feature_irreps)
+
     def _get_head(self):
         if self.head_type == "dense":
             return DenseLayer(
-                dim_feature_in=self.dim_feature_in, 
+                dim_feature_in=self.dim_feature_in,
                 dim_feature_out=self.dim_feature_out,
                 shallow_ensemble_size=self.shallow_ensemble_size,
                 **self.head_params
@@ -51,14 +76,14 @@ class BaseReadout(BaseFFLayer):
         elif self.head_type == "residual_layer":
             return Sequential(
                 ResidualLayer(
-                    dim_feature_in=self.dim_feature_in, 
+                    dim_feature_in=self.dim_feature_in,
                     dim_feature_out=self.dim_feature_in,
                     activation_fn=self.activation_fn,
                     activation_params=self.activation_params,
                     **self.head_params
                 ),
                 DenseLayer(
-                    dim_feature_in=self.dim_feature_in, 
+                    dim_feature_in=self.dim_feature_in,
                     dim_feature_out=self.dim_feature_out,
                     shallow_ensemble_size=self.shallow_ensemble_size,
                     **self.head_params
@@ -66,13 +91,32 @@ class BaseReadout(BaseFFLayer):
             )
         elif self.head_type == "residual_mlp":
             return ResidualMLP(
-                dim_feature_in=self.dim_feature_in, 
+                dim_feature_in=self.dim_feature_in,
                 dim_feature_out=self.dim_feature_out,
                 shallow_ensemble_size=self.shallow_ensemble_size,
                 activation_fn=self.activation_fn,
                 activation_params=self.activation_params,
                 **self.head_params
             )
+        elif self.head_type == "two_layer":
+            # Official-style energy MLP: Linear → SiLU/Swish → Linear.
+            act = self.activation_fn if self.activation_fn is not None else "swish"
+            return Sequential(
+                DenseLayer(
+                    dim_feature_in=self.dim_feature_in,
+                    dim_feature_out=self.dim_feature_in,
+                    activation_fn=act,
+                    activation_params=self.activation_params,
+                ),
+                DenseLayer(
+                    dim_feature_in=self.dim_feature_in,
+                    dim_feature_out=self.dim_feature_out,
+                    shallow_ensemble_size=self.shallow_ensemble_size,
+                    **self.head_params,
+                ),
+            )
+        else:
+            raise ValueError(f"Unknown head_type: {self.head_type}")
 
     def _split_field_outputs(self, head_output: Tensor) -> Dict[str, Tensor]:
         """Map head tensor columns onto named fields.
@@ -115,15 +159,16 @@ class BaseReadout(BaseFFLayer):
 
 
 class SimpleReadout(BaseReadout):
-    def __init__(self, 
-        output_fields: Set[str], 
+    def __init__(self,
+        output_fields: Set[str],
         built_layers: List[Module],
-        head_type: Literal["dense", "residual_layer", "residual_mlp"],
+        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"]="dense",
         dim_embedding: Optional[int]=None,
-        shallow_ensemble_size: int=1, 
-        keep_feature: bool=False, 
+        shallow_ensemble_size: int=1,
+        keep_feature: bool=False,
         activation_fn: Optional[ACTIVATION_KEY_TYPE]=None,
         activation_params: ACTIVATION_PARAM_TYPE=dict(),
+        feature_irreps: Optional[str]=None,
         **head_params
     ) -> None:
         super().__init__(
@@ -136,20 +181,13 @@ class SimpleReadout(BaseReadout):
             keep_feature=keep_feature,
             activation_fn=activation_fn,
             activation_params=activation_params,
+            feature_irreps=feature_irreps,
             **head_params
         )
         self.head = self._get_head()
 
     def get_output(self, atom_feature: Tensor) -> Dict[str, Tensor]:
-        if atom_feature.ndim == 2:
-            output = self.head(atom_feature)
-        elif atom_feature.ndim == 3:
-            output = self.head(atom_feature[:, :, -1])
-        else:
-            raise ValueError(
-                f"atom_feature must be 2D or 3D, got shape {tuple(atom_feature.shape)}"
-            )
-        return self._split_field_outputs(output)
+        return self._split_field_outputs(self.head(self._scalar_atom_feature(atom_feature)))
 
 
 class NSEReadout(BaseReadout):
@@ -171,13 +209,14 @@ class NSEReadout(BaseReadout):
         self,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp"] = "residual_mlp",
+        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "residual_mlp",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,
         activation_fn: Optional[ACTIVATION_KEY_TYPE] = None,
         activation_params: ACTIVATION_PARAM_TYPE = dict(),
         positive_activation_fn: POSITIVE_ACTIVATION_KEY_TYPE = "softplus",
+        feature_irreps: Optional[str] = None,
         **head_params,
     ) -> None:
         if output_fields is None:
@@ -197,16 +236,14 @@ class NSEReadout(BaseReadout):
             keep_feature=keep_feature,
             activation_fn=activation_fn,
             activation_params=activation_params,
+            feature_irreps=feature_irreps,
             **head_params,
         )
         self.head = self._get_head()
         self.positive_activation_fn = get_positive_activation_fn(positive_activation_fn)
 
     def get_output(self, atom_feature: Tensor) -> Dict[str, Tensor]:
-        if atom_feature.ndim == 2:
-            output = self.head(atom_feature)
-        elif atom_feature.ndim == 3:
-            output = self.head(atom_feature[:, :, -1])
+        output = self.head(self._scalar_atom_feature(atom_feature))
         results = dict()
         for i, output_field in enumerate(self.ordered_output_fields):
             if output_field.startswith("fa"):
@@ -228,7 +265,8 @@ class HierachicalReadout(BaseReadout):
             nhloss = 0.
             lastoutput2 = 0.
         for i in range(self.num_blocks):
-            raw_output += self.heads[i](atom_feature[:, :, i])
+            block = extract_scalar_0e(atom_feature[:, :, i], self.feature_irreps)
+            raw_output += self.heads[i](block)
             if self.use_nhloss:
                 output2 = raw_output ** 2
                 if i > 0:
@@ -253,13 +291,14 @@ class HierachicalNSEReadout(BaseReadout):
         num_blocks: int,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp"] = "residual_mlp",
+        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "residual_mlp",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,
         activation_fn: Optional[ACTIVATION_KEY_TYPE] = None,
         activation_params: ACTIVATION_PARAM_TYPE = dict(),
         positive_activation_fn: POSITIVE_ACTIVATION_KEY_TYPE = "softplus",
+        feature_irreps: Optional[str] = None,
         **head_params,
     ) -> None:
         if output_fields is None:
@@ -279,6 +318,7 @@ class HierachicalNSEReadout(BaseReadout):
             keep_feature=keep_feature,
             activation_fn=activation_fn,
             activation_params=activation_params,
+            feature_irreps=feature_irreps,
             **head_params,
         )
         self.heads = ModuleList([self._get_head() for _ in range(self.num_blocks)])
@@ -296,7 +336,8 @@ class HierachicalNSEReadout(BaseReadout):
 
         raw_output = 0.0
         for i in range(self.num_blocks):
-            raw_output = raw_output + self.heads[i](atom_feature[:, :, i])
+            block = extract_scalar_0e(atom_feature[:, :, i], self.feature_irreps)
+            raw_output = raw_output + self.heads[i](block)
 
         results: Dict[str, Tensor] = {}
         for i, output_field in enumerate(self.ordered_output_fields):
@@ -314,12 +355,13 @@ class VelocityReadout(BaseReadout):
         self,
         output_fields: Optional[Set[str]] = None,
         built_layers: List[Module] = [],
-        head_type: Literal["dense", "residual_layer", "residual_mlp"] = "dense",
+        head_type: Literal["dense", "residual_layer", "residual_mlp", "two_layer"] = "dense",
         dim_embedding: Optional[int] = None,
         shallow_ensemble_size: int = 1,
         keep_feature: bool = False,
         activation_fn: Optional[ACTIVATION_KEY_TYPE] = None,
         activation_params: ACTIVATION_PARAM_TYPE = dict(),
+        feature_irreps: Optional[str] = None,
         **head_params,
     ) -> None:
         if output_fields is None:
@@ -336,16 +378,154 @@ class VelocityReadout(BaseReadout):
             keep_feature=keep_feature,
             activation_fn=activation_fn,
             activation_params=activation_params,
+            feature_irreps=feature_irreps,
             **head_params,
         )
         self.head = self._get_head()
 
     def get_output(self, atom_feature: Tensor) -> Dict[str, Tensor]:
-        if atom_feature.ndim == 2:
-            output = self.head(atom_feature)
-        elif atom_feature.ndim == 3:
-            output = self.head(atom_feature[:, :, -1])
+        output = self.head(self._scalar_atom_feature(atom_feature))
         return {
             self.ordered_output_fields[i]: output[:, i] for i in range(self.dim_feature_out)
         }
 
+
+class EquiformerGraphAttentionReadout(BaseFFLayer):
+    """Equivariant GraphAttention head mapping full irreps → atomic scalars.
+
+    Unlike :class:`SimpleReadout` (0e extract + MLP), this consumes the full
+    ``atom_feature`` irreps tensor and graph edges, producing one 0e channel
+    per ``output_fields`` entry (e.g. ``Ea``, ``Qa``). Requires
+    ``feature_irreps`` from a prior equivariant Core.
+    """
+
+    def __init__(
+        self,
+        output_fields: Set[str],
+        built_layers: List[Module],
+        irreps_head: str = "16x0e+8x1o+4x2e",
+        num_heads: int = 2,
+        fc_neurons: Optional[List[int]] = None,
+        irreps_sh: str = "1x0e+1x1e+1x2e",
+        irreps_node_attr: str = "1x0e",
+        irreps_pre_attn: Optional[str] = None,
+        rescale_degree: bool = False,
+        nonlinear_message: bool = True,
+        alpha_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        feature_irreps: Optional[str] = None,
+        num_rbf: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        from e3nn import o3
+        from ..equiformer.attention import GraphAttention
+
+        ordered = sorted(list(output_fields))
+        super().__init__(
+            input_fields={
+                "atom_feature",
+                "idx_i_sr",
+                "idx_j_sr",
+                "vij_sr",
+                "rbf",
+                "batch_seg",
+            },
+            output_fields=set(ordered),
+        )
+        self.ordered_output_fields = ordered
+        self.dim_feature_out = len(ordered)
+
+        irreps_str = (
+            feature_irreps
+            if feature_irreps is not None
+            else _resolve_feature_irreps(built_layers)
+        )
+        if irreps_str is None:
+            raise ValueError(
+                "EquiformerGraphAttentionReadout requires feature_irreps "
+                "(from an equivariant Core) or an explicit feature_irreps=..."
+            )
+        self.feature_irreps = o3.Irreps(irreps_str)
+        self.irreps_edge_attr = o3.Irreps(irreps_sh)
+        self.irreps_node_attr = o3.Irreps(irreps_node_attr)
+
+        if fc_neurons is None:
+            fc_neurons = [64, 64]
+        if num_rbf is None:
+            num_rbf = 16
+            for layer in reversed(built_layers):
+                if hasattr(layer, "num_rbf"):
+                    num_rbf = int(layer.num_rbf)
+                    break
+                if hasattr(layer, "fc_neurons") and isinstance(layer.fc_neurons, list) and layer.fc_neurons:
+                    num_rbf = int(layer.fc_neurons[0])
+                    break
+        self.fc_neurons = [num_rbf] + list(fc_neurons)
+
+        self.head = GraphAttention(
+            irreps_node_input=self.feature_irreps,
+            irreps_node_attr=self.irreps_node_attr,
+            irreps_edge_attr=self.irreps_edge_attr,
+            irreps_node_output=o3.Irreps(f"{self.dim_feature_out}x0e"),
+            fc_neurons=self.fc_neurons,
+            irreps_head=o3.Irreps(irreps_head),
+            num_heads=num_heads,
+            irreps_pre_attn=irreps_pre_attn,
+            rescale_degree=rescale_degree,
+            nonlinear_message=nonlinear_message,
+            alpha_drop=alpha_drop,
+            proj_drop=proj_drop,
+        )
+
+    def get_output(
+        self,
+        atom_feature: Tensor,
+        idx_i_sr: Tensor,
+        idx_j_sr: Tensor,
+        vij_sr: Tensor,
+        rbf: Tensor,
+        batch_seg: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
+        from e3nn import o3
+
+        if atom_feature.ndim != 2:
+            raise ValueError(
+                "EquiformerGraphAttentionReadout expects 2D atom_feature "
+                f"(N, irreps.dim); got shape {tuple(atom_feature.shape)}"
+            )
+        if atom_feature.shape[-1] != self.feature_irreps.dim:
+            raise ValueError(
+                f"atom_feature last dim {atom_feature.shape[-1]} != "
+                f"feature_irreps.dim {self.feature_irreps.dim}"
+            )
+        n_atoms = atom_feature.shape[0]
+        if batch_seg is None:
+            batch_seg = torch.zeros(n_atoms, dtype=torch.long, device=atom_feature.device)
+        # Enerzyme edge convention: edge_src = idx_j, edge_dst = idx_i
+        edge_src = idx_j_sr
+        edge_dst = idx_i_sr
+        node_attr = torch.ones_like(atom_feature.narrow(1, 0, 1))
+        edge_sh = o3.spherical_harmonics(
+            l=self.irreps_edge_attr,
+            x=vij_sr,
+            normalize=True,
+            normalization="component",
+        )
+        outputs = self.head(
+            node_input=atom_feature,
+            node_attr=node_attr,
+            edge_src=edge_src,
+            edge_dst=edge_dst,
+            edge_attr=edge_sh,
+            edge_scalars=rbf,
+            batch=batch_seg,
+        )
+        if outputs.ndim != 2 or outputs.shape[-1] != self.dim_feature_out:
+            raise ValueError(
+                f"GraphAttention output shape {tuple(outputs.shape)} != "
+                f"(N, {self.dim_feature_out})"
+            )
+        return {
+            self.ordered_output_fields[i]: outputs.select(1, i)
+            for i in range(self.dim_feature_out)
+        }

--- a/test/equiformer_parity_utils.py
+++ b/test/equiformer_parity_utils.py
@@ -397,3 +397,36 @@ def enerzyme_atomic_energy(
     e_sum = scatter(ea, batch, dim=0, reduce="sum")
     e_graph = e_sum / (avg_num_nodes ** 0.5)
     return ea, e_graph
+
+
+def enerzyme_feature_atom_feature(
+    core: torch.nn.Module,
+    embed: torch.nn.Module,
+    rbf: torch.nn.Module,
+    za: Tensor,
+    batch: Tensor,
+    ez: Dict[str, Tensor],
+) -> Tensor:
+    """Feature-mode Core ``get_output`` → full-irreps ``atom_feature``."""
+    assert getattr(core, "output_mode", None) == "feature", (
+        "enerzyme_feature_atom_feature expects output_mode='feature'"
+    )
+    atom_emb = embed.get_atom_embedding(za)
+    rbf_vals = rbf.get_rbf(ez["Dij_sr"])
+    out = core.get_output(
+        vij_sr=ez["vij_sr"],
+        idx_i_sr=ez["idx_i_sr"],
+        idx_j_sr=ez["idx_j_sr"],
+        rbf=rbf_vals,
+        atom_embedding=atom_emb,
+        batch_seg=batch,
+    )
+    return out["atom_feature"]
+
+
+def scaled_scatter_energy(ea: Tensor, batch: Tensor, avg_num_nodes: float) -> Tensor:
+    """Upstream ScaledScatter: sum / sqrt(N_avg)."""
+    from torch_scatter import scatter
+
+    e_sum = scatter(ea.view(-1), batch, dim=0, reduce="sum")
+    return e_sum / (avg_num_nodes ** 0.5)

--- a/test/equiformer_parity_utils.py
+++ b/test/equiformer_parity_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 import torch
+from e3nn import o3
 from numpy.testing import assert_allclose
 from torch import Tensor
 
@@ -430,3 +431,34 @@ def scaled_scatter_energy(ea: Tensor, batch: Tensor, avg_num_nodes: float) -> Te
 
     e_sum = scatter(ea.view(-1), batch, dim=0, reduce="sum")
     return e_sum / (avg_num_nodes ** 0.5)
+
+
+def build_linear_rs_energy_head(
+    num_0e: int,
+    *,
+    flavor: str = "enerzyme",
+    dtype: torch.dtype = torch.float64,
+) -> torch.nn.Module:
+    """Official-style scalar energy MLP: LinearRS → SiLU → LinearRS → 1x0e.
+
+    ``flavor='official'`` uses vendored upstream modules; ``enerzyme`` uses the
+    ported LinearRS / Activation. State dicts are compatible across flavors.
+    """
+    ir = o3.Irreps(f"{num_0e}x0e")
+    ir_out = o3.Irreps("1x0e")
+    if flavor == "official":
+        from nets.fast_activation import Activation
+        from nets.graph_attention_transformer_md17 import _RESCALE
+        from nets.tensor_product_rescale import LinearRS
+    elif flavor == "enerzyme":
+        from enerzyme.models.equiformer.attention import _RESCALE
+        from enerzyme.models.equiformer.fast_activation import Activation
+        from enerzyme.models.equiformer.tensor_product import LinearRS
+    else:
+        raise ValueError(f"unknown flavor {flavor!r}")
+    head = torch.nn.Sequential(
+        LinearRS(ir, ir, rescale=_RESCALE),
+        Activation(ir, acts=[torch.nn.SiLU()]),
+        LinearRS(ir, ir_out, rescale=_RESCALE),
+    )
+    return head.to(dtype=dtype).eval()

--- a/test/test_equiformer_parity_core.py
+++ b/test/test_equiformer_parity_core.py
@@ -1,8 +1,13 @@
-"""Core latent numerical parity vs vendored Equiformer MD17."""
+"""Core latent numerical parity vs vendored Equiformer MD17.
+
+Covers both ``encode_irreps`` (parity hook) and feature-mode ``get_output``
+(full irreps ``atom_feature`` + ``feature_irreps`` contract).
+"""
 
 from __future__ import annotations
 
 import torch
+from e3nn import o3
 
 from equiformer_parity_utils import (
     assert_close,
@@ -10,27 +15,29 @@ from equiformer_parity_utils import (
     build_official_md17,
     build_radius_graph,
     copy_official_weights_to_enerzyme,
+    enerzyme_feature_atom_feature,
     load_parity_molecule,
     make_parity_hparams,
     official_node_features_after_norm,
     to_enerzyme_edges,
 )
+from enerzyme.models.irreps_tools import extract_scalar_0e, scalar_0e_dim
 
 
-def test_core_latent_parity_after_norm():
-    dtype = torch.float64
-    hp = make_parity_hparams()
+def _run_latent_parity(hp: dict, *, dtype: torch.dtype = torch.float64) -> None:
     torch.manual_seed(10)
-
     mol = load_parity_molecule(dtype=dtype)
     za, pos, r_max = mol["Za"], mol["pos"], mol["r_max"]
-    # Fixture Za max is 8; ensure within max_Za
     assert int(za.max()) <= hp["max_Za"]
     batch = torch.zeros(za.shape[0], dtype=torch.long)
 
     official = build_official_md17(hp, dtype=dtype)
     embed, rbf, core = build_enerzyme_parts(hp, output_mode="feature", dtype=dtype)
     copy_official_weights_to_enerzyme(official, embed, rbf, core)
+
+    # Feature / scalar-readout contract
+    assert core.feature_irreps == str(o3.Irreps(hp["irreps_feature"]))
+    assert core.dim_feature_out == scalar_0e_dim(hp["irreps_feature"])
 
     edge_src, edge_dst, edge_vec = build_radius_graph(pos, batch, r_max)
     ez = to_enerzyme_edges(edge_src, edge_dst, edge_vec)
@@ -40,7 +47,6 @@ def test_core_latent_parity_after_norm():
     )
     atom_emb = embed.get_atom_embedding(za)
     rbf_vals = rbf.get_rbf(ez["Dij_sr"])
-    # Sanity: RBF matches official on the same distances
     assert_close(
         rbf_vals,
         official.rbf(ez["Dij_sr"]),
@@ -49,7 +55,7 @@ def test_core_latent_parity_after_norm():
         err_msg="rbf_on_graph",
     )
 
-    ours = core.encode_irreps(
+    ours_encode = core.encode_irreps(
         vij_sr=ez["vij_sr"],
         idx_i_sr=ez["idx_i_sr"],
         idx_j_sr=ez["idx_j_sr"],
@@ -57,4 +63,30 @@ def test_core_latent_parity_after_norm():
         atom_embedding=atom_emb,
         batch_seg=batch,
     )
-    assert_close(ours, ref, atol=1e-5, rtol=1e-5, err_msg="core_latent")
+    ours_get = enerzyme_feature_atom_feature(core, embed, rbf, za, batch, ez)
+
+    assert_close(ours_encode, ref, atol=1e-5, rtol=1e-5, err_msg="encode_irreps")
+    assert_close(ours_get, ref, atol=1e-5, rtol=1e-5, err_msg="get_output_atom_feature")
+    assert_close(ours_get, ours_encode, atol=0.0, rtol=0.0, err_msg="get_output_vs_encode")
+
+    # 0e extract width matches dim_feature_out (identity when feature is pure 0e)
+    scalars = extract_scalar_0e(ours_get, core.feature_irreps)
+    assert scalars.shape[-1] == core.dim_feature_out
+
+
+def test_core_latent_parity_after_norm():
+    _run_latent_parity(make_parity_hparams())
+
+
+def test_core_latent_parity_mixed_irreps_feature():
+    """Full-irreps ``atom_feature`` when ``irreps_feature`` includes l>0.
+
+    Official MLP head (SiLU Activation) only accepts pure-0e features, so use
+    ``use_attn_head=True`` — latent path is identical; only the unused head differs.
+    """
+    _run_latent_parity(
+        make_parity_hparams(
+            irreps_feature="32x0e+16x1e+8x2e",
+            use_attn_head=True,
+        )
+    )

--- a/test/test_equiformer_parity_feature.py
+++ b/test/test_equiformer_parity_feature.py
@@ -1,0 +1,143 @@
+"""Feature-mode / modular readout parity vs vendored Equiformer MD17.
+
+Production ``SimpleReadout`` (Dense MLP after 0e extract) is *not* numerically
+aligned with the official LinearRS energy head. These tests cover:
+
+1. Feature-mode ``atom_feature`` fed into the official MLP / attn head.
+2. ``EquiformerGraphAttentionReadout`` weight-matched to official ``use_attn_head``.
+3. 0e extract + official LinearRS MLP (scalar path shared with SimpleReadout).
+"""
+
+from __future__ import annotations
+
+import torch
+from e3nn import o3
+
+from equiformer_parity_utils import (
+    assert_close,
+    build_enerzyme_parts,
+    build_official_md17,
+    build_radius_graph,
+    copy_official_weights_to_enerzyme,
+    enerzyme_feature_atom_feature,
+    load_parity_molecule,
+    make_parity_hparams,
+    official_atomic_energy,
+    official_node_features_after_norm,
+    scaled_scatter_energy,
+    to_enerzyme_edges,
+)
+from enerzyme.models.irreps_tools import extract_scalar_0e
+from enerzyme.models.layers.readout import EquiformerGraphAttentionReadout
+
+
+def test_feature_atom_feature_feeds_official_mlp_head():
+    """get_output full irreps → official LinearRS MLP → ScaledScatter."""
+    dtype = torch.float64
+    hp = make_parity_hparams(use_attn_head=False)
+    torch.manual_seed(21)
+
+    mol = load_parity_molecule(dtype=dtype)
+    za, pos, r_max = mol["Za"], mol["pos"], mol["r_max"]
+    batch = torch.zeros(za.shape[0], dtype=torch.long)
+
+    official = build_official_md17(hp, dtype=dtype)
+    embed, rbf, core = build_enerzyme_parts(hp, output_mode="feature", dtype=dtype)
+    copy_official_weights_to_enerzyme(official, embed, rbf, core)
+
+    edge_src, edge_dst, edge_vec = build_radius_graph(pos, batch, r_max)
+    ez = to_enerzyme_edges(edge_src, edge_dst, edge_vec)
+    edge_sh = o3.spherical_harmonics(
+        l=core.irreps_edge_attr, x=edge_vec, normalize=True, normalization="component"
+    )
+    rbf_vals = rbf.get_rbf(ez["Dij_sr"])
+
+    feats_ref = official_node_features_after_norm(
+        official, za, pos, batch, edge_src, edge_dst, edge_vec
+    )
+    feats_ours = enerzyme_feature_atom_feature(core, embed, rbf, za, batch, ez)
+    assert_close(feats_ours, feats_ref, atol=1e-5, rtol=1e-5, err_msg="feat_mlp")
+
+    ea_ref, e_ref = official_atomic_energy(
+        official,
+        feats_ref,
+        batch,
+        edge_src=edge_src,
+        edge_dst=edge_dst,
+        edge_sh=edge_sh,
+        edge_scalars=rbf_vals,
+    )
+    ea_ours = official.head(feats_ours).view(-1)
+    e_ours = scaled_scatter_energy(ea_ours, batch, hp["avg_num_nodes"])
+    assert_close(ea_ours, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_feature_mlp")
+    assert_close(e_ours, e_ref, atol=1e-5, rtol=1e-5, err_msg="E_feature_mlp")
+
+    # Same scalars SimpleReadout would see (pure 0e feature → identity extract)
+    scalars = extract_scalar_0e(feats_ours, core.feature_irreps)
+    assert_close(scalars, feats_ours, atol=0.0, rtol=0.0, err_msg="0e_identity_on_64x0e")
+    ea_from_0e = official.head(scalars).view(-1)
+    assert_close(ea_from_0e, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_after_0e")
+
+
+def test_equiformer_graph_attention_readout_parity():
+    """``EquiformerGraphAttentionReadout`` matches official attn energy head."""
+    dtype = torch.float64
+    hp = make_parity_hparams(use_attn_head=True)
+    torch.manual_seed(22)
+
+    mol = load_parity_molecule(dtype=dtype)
+    za, pos, r_max = mol["Za"], mol["pos"], mol["r_max"]
+    batch = torch.zeros(za.shape[0], dtype=torch.long)
+
+    official = build_official_md17(hp, dtype=dtype)
+    embed, rbf, core = build_enerzyme_parts(hp, output_mode="feature", dtype=dtype)
+    copy_official_weights_to_enerzyme(official, embed, rbf, core)
+
+    readout = EquiformerGraphAttentionReadout(
+        output_fields={"Ea"},
+        built_layers=[core],
+        irreps_head=hp["irreps_head"],
+        num_heads=hp["num_heads"],
+        fc_neurons=list(hp["fc_neurons"]),
+        irreps_sh=hp["irreps_sh"],
+        irreps_node_attr=hp["irreps_node_attr"],
+        nonlinear_message=hp["nonlinear_message"],
+        num_rbf=hp["num_rbf"],
+        feature_irreps=core.feature_irreps,
+    ).to(dtype=dtype).eval()
+    readout.head.load_state_dict(official.head.state_dict())
+
+    edge_src, edge_dst, edge_vec = build_radius_graph(pos, batch, r_max)
+    ez = to_enerzyme_edges(edge_src, edge_dst, edge_vec)
+    edge_sh = o3.spherical_harmonics(
+        l=core.irreps_edge_attr, x=edge_vec, normalize=True, normalization="component"
+    )
+    rbf_vals = rbf.get_rbf(ez["Dij_sr"])
+
+    feats_ref = official_node_features_after_norm(
+        official, za, pos, batch, edge_src, edge_dst, edge_vec
+    )
+    feats_ours = enerzyme_feature_atom_feature(core, embed, rbf, za, batch, ez)
+    assert_close(feats_ours, feats_ref, atol=1e-5, rtol=1e-5, err_msg="feat_attn")
+
+    ea_ref, e_ref = official_atomic_energy(
+        official,
+        feats_ref,
+        batch,
+        edge_src=edge_src,
+        edge_dst=edge_dst,
+        edge_sh=edge_sh,
+        edge_scalars=rbf_vals,
+    )
+    out = readout.get_output(
+        atom_feature=feats_ours,
+        idx_i_sr=ez["idx_i_sr"],
+        idx_j_sr=ez["idx_j_sr"],
+        vij_sr=ez["vij_sr"],
+        rbf=rbf_vals,
+        batch_seg=batch,
+    )
+    ea_ours = out["Ea"].view(-1)
+    e_ours = scaled_scatter_energy(ea_ours, batch, hp["avg_num_nodes"])
+    assert_close(ea_ours, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_attn_readout")
+    assert_close(e_ours, e_ref, atol=1e-5, rtol=1e-5, err_msg="E_attn_readout")

--- a/test/test_equiformer_parity_feature.py
+++ b/test/test_equiformer_parity_feature.py
@@ -87,6 +87,22 @@ def test_feature_atom_feature_feeds_official_mlp_head():
     ea_ez = ez_head(feats_ours).view(-1)
     assert_close(ea_ez, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_enerzyme_LinearRS")
 
+    # SimpleReadout(equiformer_linear_rs) with official head weights
+    from enerzyme.models.layers.readout import SimpleReadout
+
+    class _Core:
+        dim_feature_out = mul0
+        feature_irreps = core.feature_irreps
+
+    ro = SimpleReadout(
+        output_fields={"Ea"},
+        built_layers=[_Core()],
+        head_type="equiformer_linear_rs",
+    ).to(dtype=dtype).eval()
+    ro.head.load_state_dict(official.head.state_dict())
+    ea_ro = ro.get_output(feats_ours)["Ea"].view(-1)
+    assert_close(ea_ro, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_SimpleReadout_LinearRS")
+
 
 def test_mixed_irreps_0e_extract_linear_rs_energy_head_parity():
     """Mixed ``irreps_feature`` → extract 0e → official-style LinearRS energy head.

--- a/test/test_equiformer_parity_feature.py
+++ b/test/test_equiformer_parity_feature.py
@@ -4,8 +4,9 @@ Production ``SimpleReadout`` (Dense MLP after 0e extract) is *not* numerically
 aligned with the official LinearRS energy head. These tests cover:
 
 1. Feature-mode ``atom_feature`` fed into the official MLP / attn head.
-2. ``EquiformerGraphAttentionReadout`` weight-matched to official ``use_attn_head``.
-3. 0e extract + official LinearRS MLP (scalar path shared with SimpleReadout).
+2. Enerzyme LinearRS head weight-matched to official ``head`` (pure 0e).
+3. Mixed irreps → ``extract_scalar_0e`` → official-style LinearRS energy head.
+4. ``EquiformerGraphAttentionReadout`` weight-matched to official ``use_attn_head``.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from e3nn import o3
 from equiformer_parity_utils import (
     assert_close,
     build_enerzyme_parts,
+    build_linear_rs_energy_head,
     build_official_md17,
     build_radius_graph,
     copy_official_weights_to_enerzyme,
@@ -27,7 +29,7 @@ from equiformer_parity_utils import (
     scaled_scatter_energy,
     to_enerzyme_edges,
 )
-from enerzyme.models.irreps_tools import extract_scalar_0e
+from enerzyme.models.irreps_tools import extract_scalar_0e, scalar_0e_dim
 from enerzyme.models.layers.readout import EquiformerGraphAttentionReadout
 
 
@@ -77,6 +79,73 @@ def test_feature_atom_feature_feeds_official_mlp_head():
     assert_close(scalars, feats_ours, atol=0.0, rtol=0.0, err_msg="0e_identity_on_64x0e")
     ea_from_0e = official.head(scalars).view(-1)
     assert_close(ea_from_0e, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_after_0e")
+
+    # Enerzyme-ported LinearRS head with official weights must match official.head
+    mul0 = int(o3.Irreps(hp["irreps_feature"]).dim)  # pure 0e
+    ez_head = build_linear_rs_energy_head(mul0, flavor="enerzyme", dtype=dtype)
+    ez_head.load_state_dict(official.head.state_dict())
+    ea_ez = ez_head(feats_ours).view(-1)
+    assert_close(ea_ez, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_enerzyme_LinearRS")
+
+
+def test_mixed_irreps_0e_extract_linear_rs_energy_head_parity():
+    """Mixed ``irreps_feature`` → extract 0e → official-style LinearRS energy head.
+
+    Official MD17 MLP head cannot be constructed on mixed irreps (SiLU Activation
+    requires one act per irrep). After 0e extract the path matches the official
+    scalar energy MLP; we对照 vendored vs Enerzyme LinearRS with shared weights.
+    """
+    dtype = torch.float64
+    irreps_feature = "32x0e+16x1e+8x2e"
+    hp = make_parity_hparams(
+        irreps_feature=irreps_feature,
+        use_attn_head=True,  # so official MD17 constructs without scalar MLP head
+    )
+    torch.manual_seed(23)
+    mul0 = scalar_0e_dim(irreps_feature)
+
+    mol = load_parity_molecule(dtype=dtype)
+    za, pos, r_max = mol["Za"], mol["pos"], mol["r_max"]
+    batch = torch.zeros(za.shape[0], dtype=torch.long)
+
+    official = build_official_md17(hp, dtype=dtype)
+    embed, rbf, core = build_enerzyme_parts(hp, output_mode="feature", dtype=dtype)
+    copy_official_weights_to_enerzyme(official, embed, rbf, core)
+
+    edge_src, edge_dst, edge_vec = build_radius_graph(pos, batch, r_max)
+    ez = to_enerzyme_edges(edge_src, edge_dst, edge_vec)
+
+    feats_ref = official_node_features_after_norm(
+        official, za, pos, batch, edge_src, edge_dst, edge_vec
+    )
+    feats_ours = enerzyme_feature_atom_feature(core, embed, rbf, za, batch, ez)
+    assert_close(feats_ours, feats_ref, atol=1e-5, rtol=1e-5, err_msg="mixed_latent")
+    assert feats_ours.shape[-1] == o3.Irreps(irreps_feature).dim
+
+    scalars_ref = extract_scalar_0e(feats_ref, irreps_feature)
+    scalars_ours = extract_scalar_0e(feats_ours, core.feature_irreps)
+    assert scalars_ours.shape == (za.shape[0], mul0)
+    assert_close(scalars_ours, scalars_ref, atol=1e-5, rtol=1e-5, err_msg="mixed_0e")
+
+    head_off = build_linear_rs_energy_head(mul0, flavor="official", dtype=dtype)
+    head_ez = build_linear_rs_energy_head(mul0, flavor="enerzyme", dtype=dtype)
+    head_ez.load_state_dict(head_off.state_dict())
+
+    ea_ref = head_off(scalars_ref).view(-1)
+    ea_ours = head_ez(scalars_ours).view(-1)
+    e_ref = scaled_scatter_energy(ea_ref, batch, hp["avg_num_nodes"])
+    e_ours = scaled_scatter_energy(ea_ours, batch, hp["avg_num_nodes"])
+    assert_close(ea_ours, ea_ref, atol=1e-5, rtol=1e-5, err_msg="Ea_mixed_LinearRS")
+    assert_close(e_ours, e_ref, atol=1e-5, rtol=1e-5, err_msg="E_mixed_LinearRS")
+
+    # Same LinearRS head on Enerzyme scalars vs official scalars (cross check)
+    assert_close(
+        head_off(scalars_ours).view(-1),
+        ea_ref,
+        atol=1e-5,
+        rtol=1e-5,
+        err_msg="Ea_cross_scalars",
+    )
 
 
 def test_equiformer_graph_attention_readout_parity():

--- a/test/test_equiformer_readout.py
+++ b/test/test_equiformer_readout.py
@@ -132,6 +132,16 @@ def test_equiformer_graph_attention_readout_requires_irreps():
         )
 
 
+def _complete_graph(n: int):
+    idx_i, idx_j = [], []
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                idx_i.append(i)
+                idx_j.append(j)
+    return torch.tensor(idx_i, dtype=torch.long), torch.tensor(idx_j, dtype=torch.long)
+
+
 def test_equiformer_build_model_smoke_two_layer():
     model = build_model("equiformer", verbose=0)
     assert getattr(model, "feature_irreps", None) is not None
@@ -145,18 +155,13 @@ def test_equiformer_build_model_smoke_two_layer():
     za = torch.tensor([1, 6, 1, 8, 1], dtype=torch.long)
     ra = torch.randn(n, 3) * 0.3
     ra.requires_grad_(True)
-    idx_i, idx_j = [], []
-    for i in range(n):
-        for j in range(n):
-            if i != j:
-                idx_i.append(i)
-                idx_j.append(j)
+    idx_i, idx_j = _complete_graph(n)
     out = model(
         {
             "Ra": ra,
             "Za": za,
-            "idx_i": torch.tensor(idx_i),
-            "idx_j": torch.tensor(idx_j),
+            "idx_i": idx_i,
+            "idx_j": idx_j,
             "batch_seg": torch.zeros(n, dtype=torch.long),
             "offsets": None,
         }
@@ -164,6 +169,69 @@ def test_equiformer_build_model_smoke_two_layer():
     assert out["E"].shape == (1,)
     assert out["Ea"].shape == (n,)
     assert out["Qa"].shape == (n,)
+
+
+def test_equiformer_mixed_irreps_simple_readout_stack():
+    """Full stack: mixed-irreps Core → SimpleReadout 0e extract → two_layer MLP."""
+    import copy
+
+    from enerzyme.models.equiformer.core import (
+        DEFAULT_BUILD_PARAMS,
+        DEFAULT_LAYER_PARAMS,
+    )
+
+    irreps_feature = "32x0e+16x1e+8x2e"
+    mul0 = scalar_0e_dim(irreps_feature)
+    layers = copy.deepcopy(DEFAULT_LAYER_PARAMS)
+    for layer in layers:
+        if layer["name"] == "Core":
+            layer["params"]["irreps_feature"] = irreps_feature
+            layer["params"]["num_layers"] = 1
+        if layer["name"] == "SimpleReadout":
+            layer["params"]["head_type"] = "two_layer"
+            layer["params"]["activation_fn"] = "swish"
+
+    model = build_model(
+        "equiformer",
+        layer_params=layers,
+        build_params=dict(DEFAULT_BUILD_PARAMS),
+        verbose=0,
+    )
+    assert model.feature_irreps == str(o3.Irreps(irreps_feature))
+    assert model.dim_feature_out == mul0
+    assert o3.Irreps(irreps_feature).dim > mul0
+
+    readout = next(m for m in model.post_sequence if isinstance(m, SimpleReadout))
+    assert readout.head_type == "two_layer"
+    assert readout.feature_irreps == str(o3.Irreps(irreps_feature))
+    assert readout.dim_feature_in == mul0
+
+    n = 5
+    torch.manual_seed(4)
+    za = torch.tensor([1, 6, 1, 8, 1], dtype=torch.long)
+    ra = torch.randn(n, 3) * 0.3
+    ra.requires_grad_(True)
+    idx_i, idx_j = _complete_graph(n)
+    out = model(
+        {
+            "Ra": ra,
+            "Za": za,
+            "idx_i": idx_i,
+            "idx_j": idx_j,
+            "batch_seg": torch.zeros(n, dtype=torch.long),
+            "offsets": None,
+        }
+    )
+    assert out["E"].shape == (1,)
+    assert out["Ea"].shape == (n,)
+    assert out["Qa"].shape == (n,)
+    assert torch.isfinite(out["E"]).all()
+    assert torch.isfinite(out["Fa"]).all()
+
+    # Autograd through 0e extract + MLP + EnergyReduce + Force
+    out["E"].sum().backward()
+    assert ra.grad is not None
+    assert torch.isfinite(ra.grad).all()
 
 
 def test_equiformer_core_emits_full_irreps_feature():

--- a/test/test_equiformer_readout.py
+++ b/test/test_equiformer_readout.py
@@ -1,0 +1,213 @@
+"""Tests for equivariant SimpleReadout (0e extract + MLP) and GraphAttention readout."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from e3nn import o3
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from enerzyme.models.ff import build_model
+from enerzyme.models.irreps_tools import extract_scalar_0e, scalar_0e_dim
+from enerzyme.models.layers.readout import (
+    SimpleReadout,
+    EquiformerGraphAttentionReadout,
+)
+
+
+def test_extract_scalar_0e_identity_without_irreps():
+    x = torch.randn(5, 7)
+    assert torch.equal(extract_scalar_0e(x, None), x)
+
+
+def test_extract_scalar_0e_from_mixed_irreps():
+    irreps = o3.Irreps("4x0e+2x1e+1x2e")
+    n = 3
+    # Layout: [0e(4), 1e(2*3=6), 2e(1*5=5)] = 15
+    feat = torch.randn(n, irreps.dim)
+    scalars = extract_scalar_0e(feat, irreps)
+    assert scalars.shape == (n, 4)
+    assert torch.equal(scalars, feat[:, :4])
+    assert scalar_0e_dim(irreps) == 4
+
+
+def test_simple_readout_two_layer_without_irreps():
+    torch.manual_seed(0)
+    n, d = 6, 8
+    # Mock prior scalar core
+    class _Core:
+        dim_feature_out = d
+
+    ro = SimpleReadout(
+        output_fields={"Ea", "Qa"},
+        built_layers=[_Core()],
+        head_type="two_layer",
+        activation_fn="swish",
+    )
+    assert ro.feature_irreps is None
+    feat = torch.randn(n, d)
+    out = ro.get_output(feat)
+    assert out["Ea"].shape == (n,)
+    assert out["Qa"].shape == (n,)
+    assert torch.isfinite(out["Ea"]).all()
+
+
+def test_simple_readout_extracts_0e_then_mlp():
+    torch.manual_seed(1)
+    irreps = o3.Irreps("8x0e+4x1e")
+    mul0 = scalar_0e_dim(irreps)
+
+    class _Core:
+        dim_feature_out = mul0
+        feature_irreps = str(irreps)
+
+    ro = SimpleReadout(
+        output_fields={"Ea", "Qa"},
+        built_layers=[_Core()],
+        head_type="two_layer",
+        activation_fn="swish",
+    )
+    assert ro.feature_irreps == str(irreps)
+    assert ro.dim_feature_in == mul0
+    feat = torch.randn(5, irreps.dim)
+    out = ro.get_output(feat)
+    assert out["Ea"].shape == (5,)
+    assert out["Qa"].shape == (5,)
+
+
+def test_equiformer_graph_attention_readout_multi_field():
+    torch.manual_seed(2)
+    n, e = 4, 10
+    irreps = o3.Irreps("16x0e+8x1e+4x2e")
+    n_rbf = 8
+
+    class _Core:
+        dim_feature_out = scalar_0e_dim(irreps)
+        feature_irreps = str(irreps)
+        num_rbf = 8
+        fc_neurons = [8, 32]
+
+    ro = EquiformerGraphAttentionReadout(
+        output_fields={"Ea", "Qa"},
+        built_layers=[_Core()],
+        irreps_head="8x0e+4x1o+2x2e",
+        num_heads=2,
+        fc_neurons=[32],
+        irreps_sh="1x0e+1x1e+1x2e",
+        nonlinear_message=True,
+        num_rbf=n_rbf,
+    )
+    feat = torch.randn(n, irreps.dim)
+    idx_i = torch.randint(0, n, (e,))
+    idx_j = torch.randint(0, n, (e,))
+    vij = torch.randn(e, 3)
+    rbf = torch.randn(e, n_rbf)
+    batch = torch.zeros(n, dtype=torch.long)
+    out = ro.get_output(
+        atom_feature=feat,
+        idx_i_sr=idx_i,
+        idx_j_sr=idx_j,
+        vij_sr=vij,
+        rbf=rbf,
+        batch_seg=batch,
+    )
+    assert set(out) == {"Ea", "Qa"}
+    assert out["Ea"].shape == (n,)
+    assert out["Qa"].shape == (n,)
+    assert torch.isfinite(out["Ea"]).all()
+
+
+def test_equiformer_graph_attention_readout_requires_irreps():
+    class _Core:
+        dim_feature_out = 8
+
+    with pytest.raises(ValueError, match="feature_irreps"):
+        EquiformerGraphAttentionReadout(
+            output_fields={"Ea"},
+            built_layers=[_Core()],
+        )
+
+
+def test_equiformer_build_model_smoke_two_layer():
+    model = build_model("equiformer", verbose=0)
+    assert getattr(model, "feature_irreps", None) is not None
+    assert model.dim_feature_out == scalar_0e_dim(model.irreps_feature)
+    assert any(
+        isinstance(m, SimpleReadout) and m.head_type == "two_layer"
+        for m in model.post_sequence
+    )
+
+    n = 5
+    za = torch.tensor([1, 6, 1, 8, 1], dtype=torch.long)
+    ra = torch.randn(n, 3) * 0.3
+    ra.requires_grad_(True)
+    idx_i, idx_j = [], []
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                idx_i.append(i)
+                idx_j.append(j)
+    out = model(
+        {
+            "Ra": ra,
+            "Za": za,
+            "idx_i": torch.tensor(idx_i),
+            "idx_j": torch.tensor(idx_j),
+            "batch_seg": torch.zeros(n, dtype=torch.long),
+            "offsets": None,
+        }
+    )
+    assert out["E"].shape == (1,)
+    assert out["Ea"].shape == (n,)
+    assert out["Qa"].shape == (n,)
+
+
+def test_equiformer_core_emits_full_irreps_feature():
+    from enerzyme.models.equiformer.core import EquiformerCore
+    from enerzyme.models.equiformer.node_embedding_layer import EquiformerNodeEmbedding
+    from enerzyme.models.layers.rbf import ExpNormalSmearing
+
+    torch.manual_seed(3)
+    n, e = 4, 12
+    irreps = "16x0e+8x1e+4x2e"
+    feat = "8x0e+4x1e+2x2e"
+    embed = EquiformerNodeEmbedding(max_Za=16, irreps_node_embedding=irreps)
+    rbf_layer = ExpNormalSmearing(num_rbf=8, cutoff_sr=5.0)
+    core = EquiformerCore(
+        num_rbf=8,
+        irreps_node_embedding=irreps,
+        irreps_feature=feat,
+        irreps_sh="1x0e+1x1e+1x2e",
+        irreps_head="8x0e+4x1o+2x2e",
+        irreps_mlp_mid=irreps,
+        num_layers=1,
+        num_heads=2,
+        fc_neurons=[32],
+        nonlinear_message=True,
+        output_mode="feature",
+        alpha_drop=0.0,
+        proj_drop=0.0,
+        out_drop=0.0,
+    )
+    assert core.feature_irreps == str(o3.Irreps(feat))
+    assert core.dim_feature_out == scalar_0e_dim(feat)
+    za = torch.tensor([1, 6, 8, 1])
+    idx_i = torch.randint(0, n, (e,))
+    idx_j = torch.randint(0, n, (e,))
+    vij = torch.randn(e, 3)
+    dij = vij.norm(dim=-1).clamp_min(1e-6)
+    rbf = rbf_layer.get_rbf(dij)
+    atom_emb = embed.get_atom_embedding(za)
+    out = core.get_output(
+        vij_sr=vij,
+        idx_i_sr=idx_i,
+        idx_j_sr=idx_j,
+        rbf=rbf,
+        atom_embedding=atom_emb,
+        batch_seg=torch.zeros(n, dtype=torch.long),
+    )
+    assert out["atom_feature"].shape == (n, o3.Irreps(feat).dim)

--- a/test/test_simple_readout_vs_linear_rs.py
+++ b/test/test_simple_readout_vs_linear_rs.py
@@ -1,0 +1,154 @@
+"""Can SimpleReadout / Dense + rescale reproduce LinearRS?
+
+Empirical findings (pure even-scalar irreps ``Dx0e``):
+
+1. ``LinearRS`` ``rescale=True`` only multiplies weights by ``1/sqrt(fan_in)`` at
+   *init*. Runtime output rescale is commented out in upstream / our port.
+2. After init, a ``DenseLayer`` with the correctly laid-out ``tp.weight`` matches
+   ``LinearRS`` — **no** extra rescale needed.
+3. Applying an extra ``* 1/sqrt(fan_in)`` (weights or forward) **breaks** that match.
+4. Full official energy MLP still differs from ``SimpleReadout(two_layer)`` even
+   with mapped Dense weights, because official ``Activation`` wraps SiLU in
+   ``normalize2mom`` (~1.68×), while ``two_layer`` uses Enerzyme ``swish``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+from e3nn import o3
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from enerzyme.models.blocks.mlp import DenseLayer
+from enerzyme.models.equiformer.fast_activation import Activation
+from enerzyme.models.equiformer.tensor_product import LinearRS
+from enerzyme.models.layers.readout import SimpleReadout
+
+
+def _assert_close(a: torch.Tensor, b: torch.Tensor, *, atol: float, msg: str) -> None:
+    diff = (a - b).abs().max().item()
+    assert diff <= atol, f"{msg}: max |a-b|={diff} > atol={atol}"
+
+
+def _linear_rs_to_dense(lin: LinearRS, d_in: int, d_out: int) -> DenseLayer:
+    """Map LinearRS (pure 0e) → DenseLayer with equivalent affine map.
+
+    e3nn FCTP weight view is ``(mul_in, mul_attr=1, mul_out)``; Dense wants ``(out, in)``.
+    """
+    # weight_views: (d_in, 1, d_out) → transpose to (d_out, d_in)
+    w_view = next(lin.tp.weight_views()).detach()
+    assert tuple(w_view.shape) == (d_in, 1, d_out), w_view.shape
+    w = w_view.squeeze(1).T.contiguous()
+    b = lin.bias[0].detach().clone()
+    return DenseLayer(d_in, d_out, use_bias=True, initial_weight=w, initial_bias=b)
+
+
+def test_dense_matches_linear_rs_without_extra_rescale():
+    """Pure 0e LinearRS ≡ Dense with shared weights; extra rescale hurts."""
+    dtype = torch.float64
+    torch.manual_seed(0)
+    d_in, d_out, n = 64, 32, 16
+    x = torch.randn(n, d_in, dtype=dtype)
+
+    lin = (
+        LinearRS(
+            o3.Irreps(f"{d_in}x0e"),
+            o3.Irreps(f"{d_out}x0e"),
+            bias=True,
+            rescale=True,
+        )
+        .to(dtype)
+        .eval()
+    )
+    dense = _linear_rs_to_dense(lin, d_in, d_out).to(dtype)
+    _assert_close(lin(x), dense(x), atol=1e-12, msg="Dense(tp.weight) vs LinearRS")
+
+    fan_in = d_in  # Dx0e × 1x0e → Fx0e, uvw fan_in = D
+    sqrt_k = fan_in**-0.5
+    dense_extra = DenseLayer(
+        d_in,
+        d_out,
+        use_bias=True,
+        initial_weight=dense.weight.detach() * sqrt_k,
+        initial_bias=dense.bias.detach().clone(),
+    ).to(dtype)
+    err_extra = (lin(x) - dense_extra(x)).abs().max().item()
+    assert err_extra > 1e-3, (
+        "extra 1/sqrt(fan_in) on Dense weights should break LinearRS match, "
+        f"got maxdiff={err_extra}"
+    )
+
+    err_fwd = (lin(x) - dense(x) * sqrt_k).abs().max().item()
+    assert err_fwd > 1e-3, (
+        f"forward Dense*sqrt_k should not match LinearRS, got maxdiff={err_fwd}"
+    )
+
+
+def test_linear_rs_rescale_false_needs_no_init_mul():
+    """With rescale=False, correctly laid-out tp.weight still matches Dense."""
+    dtype = torch.float64
+    torch.manual_seed(1)
+    d_in, d_out, n = 16, 8, 5
+    x = torch.randn(n, d_in, dtype=dtype)
+    lin = (
+        LinearRS(
+            o3.Irreps(f"{d_in}x0e"),
+            o3.Irreps(f"{d_out}x0e"),
+            bias=True,
+            rescale=False,
+        )
+        .to(dtype)
+        .eval()
+    )
+    dense = _linear_rs_to_dense(lin, d_in, d_out).to(dtype)
+    _assert_close(lin(x), dense(x), atol=1e-12, msg="rescale=False Dense match")
+
+
+def test_simple_readout_two_layer_vs_linear_rs_head_with_mapped_weights():
+    """Mapped Dense matches LinearRS layers; SimpleReadout(swish) ≠ official act."""
+    dtype = torch.float64
+    torch.manual_seed(2)
+    d, n = 64, 10
+    x = torch.randn(n, d, dtype=dtype)
+
+    lin1 = LinearRS(o3.Irreps(f"{d}x0e"), o3.Irreps(f"{d}x0e"), rescale=True).to(dtype)
+    act_official = Activation(o3.Irreps(f"{d}x0e"), acts=[torch.nn.SiLU()])
+    lin2 = LinearRS(o3.Irreps(f"{d}x0e"), o3.Irreps("1x0e"), rescale=True).to(dtype)
+    head_rs = torch.nn.Sequential(lin1, act_official, lin2).eval()
+
+    d1 = _linear_rs_to_dense(lin1, d, d).to(dtype)
+    d2 = _linear_rs_to_dense(lin2, d, 1).to(dtype)
+
+    y_rs = head_rs(x).view(-1)
+    y_dense_official_act = d2(act_official(d1(x))).view(-1)
+    _assert_close(
+        y_rs,
+        y_dense_official_act,
+        atol=1e-11,
+        msg="Dense+official Activation vs LinearRS head",
+    )
+
+    class _Core:
+        dim_feature_out = d
+
+    ro = SimpleReadout(
+        output_fields={"Ea"},
+        built_layers=[_Core()],
+        head_type="two_layer",
+        activation_fn="swish",
+    ).to(dtype)
+    with torch.no_grad():
+        ro.head[0].weight.copy_(d1.weight)
+        ro.head[0].bias.copy_(d1.bias)
+        ro.head[1].weight.copy_(d2.weight)
+        ro.head[1].bias.copy_(d2.bias)
+
+    y_simple = ro.get_output(x)["Ea"]
+    err_swish = (y_rs - y_simple).abs().max().item()
+    assert err_swish > 1e-3, (
+        "SimpleReadout(swish) should still differ from LinearRS+normalize2mom(SiLU) "
+        f"even with mapped weights; got maxdiff={err_swish}"
+    )

--- a/test/test_simple_readout_vs_linear_rs.py
+++ b/test/test_simple_readout_vs_linear_rs.py
@@ -152,3 +152,48 @@ def test_simple_readout_two_layer_vs_linear_rs_head_with_mapped_weights():
         "SimpleReadout(swish) should still differ from LinearRS+normalize2mom(SiLU) "
         f"even with mapped weights; got maxdiff={err_swish}"
     )
+
+
+def test_equiformer_linear_rs_head_matches_official_energy_mlp():
+    """head_type=equiformer_linear_rs reproduces LinearRS + normalize2mom(SiLU)."""
+    dtype = torch.float64
+    torch.manual_seed(3)
+    d, n = 64, 12
+    x = torch.randn(n, d, dtype=dtype)
+
+    lin1 = LinearRS(o3.Irreps(f"{d}x0e"), o3.Irreps(f"{d}x0e"), rescale=True).to(dtype)
+    act = Activation(o3.Irreps(f"{d}x0e"), acts=[torch.nn.SiLU()])
+    lin2 = LinearRS(o3.Irreps(f"{d}x0e"), o3.Irreps("1x0e"), rescale=True).to(dtype)
+    head_rs = torch.nn.Sequential(lin1, act, lin2).eval()
+
+    class _Core:
+        dim_feature_out = d
+
+    ro = SimpleReadout(
+        output_fields={"Ea"},
+        built_layers=[_Core()],
+        head_type="equiformer_linear_rs",
+    ).to(dtype)
+    assert ro.head_type == "equiformer_linear_rs"
+    ro.head.load_state_dict(head_rs.state_dict())
+
+    y_rs = head_rs(x).view(-1)
+    y_ro = ro.get_output(x)["Ea"]
+    _assert_close(y_rs, y_ro, atol=1e-12, msg="equiformer_linear_rs vs official MLP")
+
+
+def test_equiformer_linear_rs_rejects_shallow_ensemble():
+    class _Core:
+        dim_feature_out = 8
+
+    try:
+        SimpleReadout(
+            output_fields={"Ea"},
+            built_layers=[_Core()],
+            head_type="equiformer_linear_rs",
+            shallow_ensemble_size=2,
+        )
+    except ValueError as exc:
+        assert "shallow_ensemble" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for shallow_ensemble_size>1")


### PR DESCRIPTION
## Summary
- Equivariant Core contract: `atom_feature` may be full irreps; `feature_irreps` + `dim_feature_out` (= 0e count). Equiformer `feature` mode emits full irreps.
- `SimpleReadout` extracts 0e when `feature_irreps` is set, then runs existing / new `two_layer` MLP heads (no GraphAttention inside Simple).
- New `EquiformerGraphAttentionReadout` for multi-field atomic scalars over full irreps + graph edges.
- Equiformer default stack + FF09 use `SimpleReadout` + `two_layer`; YAML comments show how to switch to the attn readout.

## Test plan
- [x] `pytest test/test_equiformer_readout.py test/test_equiformer.py`
- [x] Confirm FF09 builds with default SimpleReadout


Made with [Cursor](https://cursor.com)