### PR TITLE
Dedupe overlapping global and per-dataset transforms

### DIFF
--- a/docs/user_guide/data/datahub_reference.rst
+++ b/docs/user_guide/data/datahub_reference.rst
@@ -53,7 +53,10 @@ Production configs use :code:`datasets:` so training and validation can point to
 
 :code:`global_transforms` apply across all datasets. Per-dataset
 :code:`transforms:` entries are mapped to dataset-local preprocessing
-(:code:`SingleDataHub.preprocessings`).
+(:code:`SingleDataHub.preprocessings`). Keys that already appear under
+:code:`global_transforms` are omitted from that remapping so overlapping
+configs (common in active-learning YAML) are not applied twice; when values
+differ, :code:`global_transforms` wins.
 
 Feature and target mapping
 --------------------------

--- a/enerzyme/data/datahub.py
+++ b/enerzyme/data/datahub.py
@@ -833,12 +833,20 @@ class SingleDataHub:
         return FieldDataset({k: v for k, v in self.data.items() if k in self.target_types})
 
 
-def _coerce_dataset_params(dataset_params: Dict[str, Any]) -> Dict[str, Any]:
+def _coerce_dataset_params(
+    dataset_params: Dict[str, Any],
+    global_transforms: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Map YAML per-dataset ``transforms`` onto ``SingleDataHub.preprocessings``.
 
     Historical multi-dataset configs use ``transforms:`` under each dataset entry,
     but :class:`SingleDataHub` expects ``preprocessings``. Explicit ``preprocessings``
-    wins on key conflicts.
+    wins on key conflicts with remapped ``transforms``.
+
+    Keys already present in ``global_transforms`` are omitted from the remapped
+    preprocessings so overlapping AL configs (same dict under both) are not
+    applied twice. When values differ, ``global_transforms`` wins and a warning
+    is logged.
     """
     params = dict(dataset_params)
     transforms = params.pop("transforms", None)
@@ -849,7 +857,25 @@ def _coerce_dataset_params(dataset_params: Dict[str, Any]) -> Dict[str, Any]:
             merged.update(existing)
             params["preprocessings"] = merged
         else:
-            params["preprocessings"] = transforms
+            params["preprocessings"] = dict(transforms)
+    preprocessings = params.get("preprocessings")
+    if preprocessings and global_transforms:
+        kept = {}
+        for key, value in preprocessings.items():
+            if key in global_transforms:
+                if global_transforms[key] != value:
+                    logger.warning(
+                        "Dropping per-dataset preprocessing %r=%r because "
+                        "global_transforms already defines %r=%r; global wins "
+                        "to avoid double application.",
+                        key,
+                        value,
+                        key,
+                        global_transforms[key],
+                    )
+                continue
+            kept[key] = value
+        params["preprocessings"] = kept or None
     return params
 
 
@@ -869,20 +895,22 @@ class DataHub:
                 params["global_transforms"] = params.get("transforms", None)
             self.datahubs = {"default": SingleDataHub(dump_dir=dump_dir, **params)}
         elif isinstance(datasets, list):
+            global_transforms = params.get("global_transforms", None)
             self.datahubs = {
                 str(i): SingleDataHub(
                     dump_dir=dump_dir,
-                    global_transforms=params.get("global_transforms", None),
-                    **_coerce_dataset_params(dataset_params),
+                    global_transforms=global_transforms,
+                    **_coerce_dataset_params(dataset_params, global_transforms),
                 )
                 for i, dataset_params in enumerate(datasets)
             }
         elif isinstance(datasets, dict):
+            global_transforms = params.get("global_transforms", None)
             self.datahubs = {
                 name: SingleDataHub(
                     dump_dir=dump_dir,
-                    global_transforms=params.get("global_transforms", None),
-                    **_coerce_dataset_params(dataset_params),
+                    global_transforms=global_transforms,
+                    **_coerce_dataset_params(dataset_params, global_transforms),
                 )
                 for name, dataset_params in datasets.items()
             }

--- a/test/test_uniform_qs_init_transform.py
+++ b/test/test_uniform_qs_init_transform.py
@@ -72,6 +72,32 @@ def test_coerce_dataset_params_preprocessings_wins_on_conflict():
     assert out["preprocessings"]["negative_gradient"] is True
 
 
+def test_coerce_dataset_params_drops_keys_overlapping_global_transforms():
+    out = _coerce_dataset_params(
+        {
+            "data_path": "x.pkl",
+            "transforms": {
+                "atomic_energy": "/ae.csv",
+                "negative_gradient": True,
+                "uniform_qs_init": True,
+            },
+        },
+        global_transforms={
+            "atomic_energy": "/ae.csv",
+            "negative_gradient": True,
+        },
+    )
+    assert out["preprocessings"] == {"uniform_qs_init": True}
+
+
+def test_coerce_dataset_params_global_wins_when_overlap_values_differ():
+    out = _coerce_dataset_params(
+        {"transforms": {"negative_gradient": False}},
+        global_transforms={"negative_gradient": True},
+    )
+    assert out["preprocessings"] is None
+
+
 def _write_tiny_qs_pickle(path: Path) -> None:
     frames = [
         {
@@ -172,3 +198,55 @@ def test_datahub_multidataset_transforms_remap_enables_uniform_qs(tmp_path: Path
     assert train.preprocessings == {"uniform_qs_init": True}
     assert train._populate_uniform_qs_init is True
     _assert_init_features(train)
+
+
+def test_datahub_overlapping_transforms_apply_atomic_energy_once(tmp_path: Path):
+    """Legacy AL YAML duplicates transforms under datasets and global_transforms."""
+    ae_csv = tmp_path / "ae.csv"
+    ae_csv.write_text("atom_type,atomic_energy\nH,-0.5\nC,-10.0\nO,-20.0\n")
+    frames = [
+        {
+            "atom_type": ["C", "O"],
+            "coord": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0]],
+            "total_chrg": 0,
+            "energy": -35.5,
+            "grad": [[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0]],
+            "dipole": [0.0, 0.0, 0.0],
+        }
+    ]
+    pkl = tmp_path / "labeled.pkl"
+    with open(pkl, "wb") as f:
+        pickle.dump(frames, f)
+
+    transforms = {
+        "atomic_energy": str(ae_csv),
+        "negative_gradient": True,
+    }
+    hub = DataHub(
+        dump_dir=str(tmp_path / "out"),
+        global_transforms=transforms,
+        datasets={
+            "training": {
+                "data_path": str(pkl),
+                "data_format": "pickle",
+                "preload": True,
+                "neighbor_list": "",
+                "compressed": False,
+                "features": {
+                    "Ra": "coord",
+                    "Za": "atom_type",
+                    "Q": "total_chrg",
+                    "N": None,
+                },
+                "targets": {"E": "energy", "Fa": "grad"},
+                "transforms": transforms,
+            }
+        },
+    )
+    train = hub.datahubs["training"]
+    assert train.preprocessings in (None, {})
+    e = float(np.asarray(train.targets["E"]).ravel()[0])
+    fa0 = np.asarray(train.targets["Fa"][0][0])
+    # once: -35.5 - (-10 - 20) = -5.5; twice would be +24.5
+    assert np.isclose(e, -5.5)
+    assert np.allclose(fa0, [-0.1, 0.0, 0.0])


### PR DESCRIPTION
## Summary
- When multi-dataset YAML remaps per-dataset `transforms` → `preprocessings`, omit keys already defined under `global_transforms` (global wins; warn if values differ).
- Restores pre-`f1bb61b` AL training semantics for Enerzymette configs that duplicate the same transform dict in both places (fixes double `atomic_energy` / cancelled `negative_gradient`).
- Docs + unit/integration coverage for overlap and once-applied atomic energy.

## Test plan
- [x] `pytest test/test_uniform_qs_init_transform.py`
- [x] frag6-4 smoke train with legacy duplicate `train.yaml` (once-subtract E, Fa=-grad, sane val_E_rmse)


Made with [Cursor](https://cursor.com)