### PR TITLE
Add xTB / PySCF NAO Q–S priors and qs_delta transforms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ autosummary_ignore_module_all = False
 
 # Custom autosummary templates
 autosummary_template_path = ['_templates/autosummary']
-autosummary_mock_imports = ["nequip", "xequinet"]
+autosummary_mock_imports = ["nequip", "xequinet", "pyscf", "gpu4pyscf", "tblite"]
 napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -443,11 +443,33 @@ Liao et al. (2026, arXiv:2604.09130) lives under :code:`enerzyme/models/equiform
 E2Former (:code:`e2former`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- :code:`test_e2former_parity_ops.py` — E2Former Wigner-6j / SO2 TP numerical parity vs vendored UBio-MolFM fixtures
-- :code:`test_e2former_v2_core.py` — E2Former-V2 SO2 attention shapes, build_model E/F, SO(3) / translation, YAML smoke
-- :code:`test_e2former_so2_tp.py` — EAAS / SO2 TP shapes, rotation equivariance, Triton PyTorch fallback
-- :code:`test_e2former_triton_parity.py` — QK index convention / CPU fallback guards; CUDA Triton vs PyTorch parity (skipped without GPU)
-- :code:`test_e2former_lsr_core.py` — E2Former-LSR shapes, kmeans/precomputed fragments, bipartite graph batch isolation, build_model E/F, SO(3) / translation, YAML smoke
+Li et al. (NeurIPS 2025 Spotlight, arXiv:2501.19216) lives under :code:`enerzyme/models/e2former/`,
+adapted from `liyy2/E2Former <https://github.com/liyy2/E2Former>`_ (MIT). Register via
+:code:`get_ff_core("e2former")`. The Core uses Wigner-6j factorization for equivariant
+attention, reuses shared :code:`so3` RMSNorm / :code:`SO3Linear` and EquiformerV2's S²
+:code:`FeedForwardNetwork`, and emits :code:`atom_feature` / :code:`atom_sphere_feature`.
+Compose :code:`SimpleReadout` + :code:`EnergyReduce` / :code:`Force` outside the Core.
+Requires equal channel multiplicity across degrees. Example:
+:code:`e2former_layers_example.yaml`. Tests: :code:`test/test_e2former_core.py`,
+:code:`test/test_e2former_wigner6j.py`, :code:`test/test_e2former_parity_ops.py`.
+
+E2Former-V2 (:code:`e2former_v2`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Huang et al. (2026, arXiv:2601.16622) **reuses** :code:`E2FormerCore` with defaults in
+:code:`e2former/v2.py` (:code:`attn_type: so2-first-order`, optional Triton sparse QK).
+Same latent contract and post-core stack as V1. Example:
+:code:`e2former_v2_layers_example.yaml`. Tests: :code:`test/test_e2former_v2_core.py`,
+:code:`test/test_e2former_so2_tp.py`, :code:`test/test_e2former_triton_parity.py`.
+
+E2Former-LSR (:code:`e2former_lsr`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Wang et al. (arXiv:2601.03774) adds atom–fragment bipartite long-range attention on top of
+the short-range E2Former package (:code:`cutoff_lr`, :code:`long_layers`, late fusion).
+Fragmentation defaults to online k-means; :code:`fragment_mode: precomputed` uses Datahub
+:code:`cluster_ids`. Still emits :code:`atom_feature` / :code:`atom_sphere_feature`.
+Example: :code:`e2former_lsr_layers_example.yaml`. Tests: :code:`test/test_e2former_lsr_core.py`.
 
 DPA4 (:code:`dpa4`)
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -23,7 +23,7 @@ Environment files
 Three dependency contexts matter:
 
 - **Runtime** — :code:`setup.py` :code:`install_requires` (NumPy, PyTorch, ASE, RDKit, Lightning, etc.)
-- **Development** — :code:`requirements-dev.yaml` (conda env for day-to-day coding)
+- **Development** — :code:`requirements.yaml` at the repo root (conda env for day-to-day coding; see :doc:`/getting_started/installation`)
 - **Documentation** — :code:`docs/requirements.yaml` (Sphinx, pydata theme, editable install for autodoc)
 
 For a first-time contributor setup, follow :doc:`/getting_started/installation`, then install in editable mode as above.

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -265,7 +265,7 @@ Avoid renaming without strong reason:
 
 - :code:`out/config.yaml`
 - :code:`out/processed_dataset_<hash>/`
-- :code:`out/FF<id>-<arch>[-suffix]/best/` and :code:`last/`
+- :code:`out/FF<id>-<arch>[-suffix]/` — :code:`model_best.pth` / :code:`model_last.pth` (committee: :code:`model0_best.pth`, …)
 - Simulation outputs such as :code:`md.traj.xyz`, :code:`plumed.traj.xyz`, :code:`neb.xyz`
 
 Testing strategy

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -421,7 +421,7 @@ When to split into sub-pages
 Keep this single page while the contributor surface is still evolving. Split into :code:`docs/developer_guide/` when any section grows past ~200 lines or needs its own deep dive (for example, a dedicated “Adding a new architecture” cookbook). The entry :code:`docs/developer_guide.rst` would then become a short overview plus layered toctree, mirroring :doc:`/user_guide`.
 
 External UMA (:code:`uma_qs`)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Register in :code:`get_ff_core` like other architectures. Keep fairchem imports inside :code:`enerzyme/models/esen/` so non-UMA installs do not import it until selected. Prefer shared :code:`layers/readout.py` and :code:`layers/spin.py` for Q/S heads. Package name :code:`esen/` is historical (UMA / eSCN-MD lineage); it is **not** the 2023 paper eSCN.
 
@@ -465,17 +465,17 @@ TECE (:code:`tece`)
 Xu et al. (arXiv:2607.10664) lives under :code:`enerzyme/models/tece/` (:code:`core.py`, :code:`interaction.py`), adapted from `xvzemin/tace <https://github.com/xvzemin/tace>`_ v0.2.0 (MIT). Register via :code:`get_ff_core("tece")`. The Core seeds equivariant features from scalar embeddings, then stacks uvSO2 interactions with Edge Cluster Expansion (:code:`ComplexProductBasis`) and Radial Rotary Attention, plus node-side :code:`CgtpACE` reused from TACE. Shared SO(2) primitives (:code:`WignerD` recursive/direct, :code:`uvSO2Linear`, :code:`SO2Gate`, :code:`LayoutTransform`) live in :code:`enerzyme/models/so3/`. Requires :code:`Lmax == lmax`. Do not conflate RRA with EFA Euclidean RoPE. Emit :code:`atom_feature` for :code:`SimpleReadout`. Example: :code:`tece_layers_example.yaml`. Tests: :code:`test/test_tece_*.py`. Enerzymette: :code:`architecture: tece` + resolved :code:`config.yaml`.
 
 So3krates (:code:`so3krates`)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Frank et al. (NeurIPS 2022) lives under :code:`enerzyme/models/so3krates/` with shared :code:`RealSphericalHarmonics` and :code:`L0Contraction` (:code:`cgmatrix.npz`) in :code:`enerzyme/models/so3/`. The Core emits invariant :code:`atom_feature` and SPHC :code:`atom_sphere_feature` (``[N, m_tot]``, not eSCN/EquiformerV2 channel layout). Compose :code:`SimpleReadout` + :code:`EnergyReduce` / :code:`Force` (and optional ZBL / electrostatics / dispersion) outside the Core. Offline parity vs So3krates-torch fixtures: :code:`test/test_so3krates_parity_ops.py`. Enerzymette only needs :code:`architecture: so3krates` plus a resolved :code:`config.yaml`.
 
 SO3LR (:code:`so3lr`)
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 Kabylda et al. (JACS 2025) is registered as :code:`architecture: so3lr` but **reuses** :code:`So3kratesCore`. Defaults and layers live in :code:`enerzyme/models/so3krates/so3lr.py`. Physics uses shared modules with SO3LR options: :code:`ZBLRepulsionEnergy` (:code:`switch_off`), :code:`ElectrostaticEnergy` (:code:`flavor: SO3LR`), :code:`TSQDODispersionEnergy` under :code:`enerzyme/models/layers/dispersion/`, plus :code:`SimpleReadout(Qa)` / :code:`AtomicAffine` / :code:`HirshfeldReadout` / :code:`ChargeSpinEmbedding`. Grimme D3/D4 remain for PhysNet/SpookyNet stacks. Cutoff alias :code:`phys` → polynomial. Tests: :code:`test/test_so3lr.py`. Enerzymette: :code:`architecture: so3lr` + resolved :code:`config.yaml` (see :code:`enerzyme/config/so3lr_layers_example.yaml`).
 
 EFA (:code:`efa` / :code:`so3lr_efa`) and SpookyNet :code:`use_efa`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Frank et al. (arXiv:2412.08541) — shared package :code:`enerzyme/models/efa/` (ERoPE + Lebedev linear attention). Lebedev point tables live in :code:`enerzyme/models/so3/data/lebedev_grids.npz` (e3x Apache-2.0) and are imported from :code:`enerzyme.models.so3.lebedev` (also re-exported on the :code:`efa` package).
 
@@ -485,11 +485,11 @@ Frank et al. (arXiv:2412.08541) — shared package :code:`enerzyme/models/efa/` 
 * Tests: :code:`test/test_efa.py`. Examples: :code:`efa_layers_example.yaml`, :code:`so3lr_efa_layers_example.yaml`.
 
 AllScAIP (:code:`AllScAIP`)
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Enerzyme's AllScAIP is an **experimental, modified (魔改)** attention Core under :code:`enerzyme/models/allscaip/`. Do **not** treat it as the recommended production model; document regressions and keep example FF entries inactive unless deliberately testing. The Core returns :code:`atom_feature` only — YAML stacks must include :code:`SimpleReadout` / NSE heads (see :code:`DEFAULT_LAYER_PARAMS`).
 
 Flow matching (:code:`uma_flow_qs`)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Requires optional :code:`torchdiffeq` (:code:`pip install -e ".[flow]"`) for ODE integration in :code:`enerzyme/tasks/generator_ode.py`. Keep ODE utilities in tasks/, not inside Core modules.

--- a/docs/getting_started/active_learning.rst
+++ b/docs/getting_started/active_learning.rst
@@ -217,7 +217,9 @@ A practical task directory should contain only stable, human-authored inputs at 
     |-- FF02-SpookyNet-1/
     `-- ...
 
-The directory :code:`/home/gridsan/wlluo/multiscale/MLFF/enerzyme-new/spookynet/L3-COMT_2ZVJ-frag6-1` follows this pattern:
+The layout above is the portable pattern to follow. For a tiny ASELMDB / annotate /
+Enerzymette AL smoke with repo-relative paths, see :code:`example/L3-COMT-aselmdb-smoke/`
+(and that directory's :code:`README.md`). In a full AL task directory:
 
 - :code:`al.sh` is the batch launcher.
 - :code:`config/` stores the four templates passed to :code:`-sc`, :code:`-ac`, :code:`-ec`, and :code:`-tc`.

--- a/docs/getting_started/bond_and_utilities.rst
+++ b/docs/getting_started/bond_and_utilities.rst
@@ -6,7 +6,7 @@ This page covers Enerzyme CLI utilities and `Enerzymette <https://github.com/Ben
 Bond order assignment (:code:`enerzyme bond`)
 ---------------------------------------------
 
-Guess bond orders for enzymatic cluster structures from a PDB file. Compatible with `QuantumPDB <https://github.com/davidkastner/quantumPDB>`_ cluster outputs.
+Guess bond orders for enzymatic cluster structures from a PDB file. Compatible with `QuantumPDB <https://github.com/hjkgrp/quantumPDB>`_ cluster outputs.
 
 .. code-block:: bash
 

--- a/docs/getting_started/fragment_extraction.rst
+++ b/docs/getting_started/fragment_extraction.rst
@@ -12,7 +12,7 @@ Basic command
 
 Arguments match :code:`predict` plus:
 
-- :code:`-s` / :code:`--skip_prediction` — skip inference if prediction pickles already exist in :code:`output_dir`
+- :code:`-s` / :code:`--skip_prediction` — skip inference if prediction pickles already exist under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir`
 
 Workflow
 --------

--- a/docs/getting_started/fragment_extraction.rst
+++ b/docs/getting_started/fragment_extraction.rst
@@ -12,7 +12,7 @@ Basic command
 
 Arguments match :code:`predict` plus:
 
-- :code:`-s` / :code:`--skip_prediction` — skip inference if prediction pickles already exist under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir`
+- :code:`-s` / :code:`--skip_prediction` — skip inference and load existing **simple-predict** pickles under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir` (from a prior :code:`enerzyme predict ... -s`; metric-mode pickles are not compatible)
 
 Workflow
 --------

--- a/docs/getting_started/fragment_extraction.rst
+++ b/docs/getting_started/fragment_extraction.rst
@@ -69,11 +69,14 @@ Prerequisites
 Example with skip prediction
 ----------------------------
 
-After a prior :code:`predict` or :code:`extract` run saved pickles:
+Reuse the **same** :code:`-o` as a prior simple-predict run so pickles under
+:code:`processed_dataset_<hash>/` are found (fragments are also written under that
+:code:`output_dir`):
 
 .. code-block:: bash
 
-    enerzyme extract -c extract.yaml -o extract_out/ -m model_dir/ -mc train.yaml -s
+    enerzyme predict -c extract.yaml -o work/ -m model_dir/ -mc train.yaml -s
+    enerzyme extract -c extract.yaml -o work/ -m model_dir/ -mc train.yaml -s
 
 Outputs
 -------

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -21,7 +21,7 @@ We recommend creating a conda environment from :code:`requirements.yaml`:
     conda env create -f requirements.yaml
     conda activate enerzyme
 
-The file installs core dependencies. For a pinned release for reproducibility of paper results, install from the :code:`requirements.yaml` in the corresponding subdirectory of :code:`examples/`. The environment may have a different name from :code:`enerzyme`.
+The file installs core dependencies. For a pinned release for reproducibility of paper results, install from the :code:`requirements.yaml` in the corresponding subdirectory of :code:`example/` (for example :code:`example/NNP4MTase/requirements.yaml`). The environment may have a different name from :code:`enerzyme`.
 
 Install torch-scatter
 ---------------------

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -52,7 +52,7 @@ Some workflows need extra packages or external programs that are **not** install
 - **XPaiNN models** — :code:`XequiNet`, SciPy, PySCF, pydantic
 - **PLUMED enhanced sampling** — :code:`py-plumed` and a PLUMED-enabled build
 - **QM annotation with TeraChem** — TeraChem (licensed)
-- **Bond assignment** — QuantumPDB https://github.com/hjkgrp/quantumPDB (optional but recommended)
+- **Bond assignment** — QuantumPDB https://github.com/davidkastner/quantumPDB (optional but recommended)
 - **Enerzymette launchers** — install from the Enerzymette repository https://github.com/Benzoin96485/Enerzymette with :code:`pip install -e .`
 - **fairchem** — install from the fairchem repository https://github.com/Benzoin96485/fairchem
 - **UMA flow matching** (:code:`architecture: uma_flow_qs`) — :code:`pip install -e ".[flow]"` (installs :code:`torchdiffeq`) and fairchem

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -52,7 +52,7 @@ Some workflows need extra packages or external programs that are **not** install
 - **XPaiNN models** — :code:`XequiNet`, SciPy, PySCF, pydantic
 - **PLUMED enhanced sampling** — :code:`py-plumed` and a PLUMED-enabled build
 - **QM annotation with TeraChem** — TeraChem (licensed)
-- **Bond assignment** — QuantumPDB https://github.com/davidkastner/quantumPDB (optional but recommended)
+- **Bond assignment** — QuantumPDB https://github.com/hjkgrp/quantumPDB (optional but recommended)
 - **Enerzymette launchers** — install from the Enerzymette repository https://github.com/Benzoin96485/Enerzymette with :code:`pip install -e .`
 - **fairchem** — install from the fairchem repository https://github.com/Benzoin96485/fairchem
 - **UMA flow matching** (:code:`architecture: uma_flow_qs`) — :code:`pip install -e ".[flow]"` (installs :code:`torchdiffeq`) and fairchem

--- a/docs/getting_started/prediction.rst
+++ b/docs/getting_started/prediction.rst
@@ -15,7 +15,7 @@ Arguments:
 - :code:`-c` / :code:`--config_path` — prediction config (test :code:`Datahub`, optional :code:`Metric`)
 - :code:`-m` / :code:`--model_dir` — directory containing trained checkpoints (from :code:`enerzyme train -o`)
 - :code:`-mc` / :code:`--model_config_path` — training config used to build the model (defaults to :code:`model_dir/config.yaml` if omitted)
-- :code:`-o` / :code:`--output_dir` — where CSV summaries and per-model pickles are written
+- :code:`-o` / :code:`--output_dir` — Datahub dump directory and location of the metrics CSV (prediction pickles land under each dataset's :code:`processed_dataset_<hash>/` there)
 
 Configuration
 -------------
@@ -68,8 +68,10 @@ Outputs
 
 Enerzyme loads all **active** models from the model config, runs prediction, and writes:
 
-- Per-model prediction pickles under each model subfolder in :code:`output_dir`
-- A summary CSV in :code:`output_dir` with aggregated metrics when :code:`Metric` is defined
+- Per-model prediction pickles named :code:`{FF_ID}-prediction.pkl` under each dataset's
+  :code:`processed_dataset_<hash>/` directory inside :code:`output_dir` (the Datahub
+  :code:`preload_path`; this is also where :code:`enerzyme extract -s` expects them)
+- A summary CSV :code:`metric.csv` in :code:`output_dir` with aggregated metrics when :code:`Metric` is defined
 
 .. note::
     Uncertainty fields require a committee-trained model or another UQ-capable setup. See :doc:`active_learning`.

--- a/docs/getting_started/prediction.rst
+++ b/docs/getting_started/prediction.rst
@@ -70,8 +70,13 @@ Enerzyme loads all **active** models from the model config, runs prediction, and
 
 - Per-model prediction pickles named :code:`{FF_ID}-prediction.pkl` under each dataset's
   :code:`processed_dataset_<hash>/` directory inside :code:`output_dir` (the Datahub
-  :code:`preload_path`; this is also where :code:`enerzyme extract -s` expects them)
+  :code:`preload_path`)
 - A summary CSV :code:`metric.csv` in :code:`output_dir` with aggregated metrics when :code:`Metric` is defined
+
+Default (metric) pickles store evaluation columns such as :code:`predict_E` / :code:`predict_Fa`.
+:code:`enerzyme extract -s` instead expects **simple-predict** pickles (from
+:code:`enerzyme predict ... -s`), which keep raw prediction fields like :code:`Ra` for
+fragment building. Without :code:`-s`, :code:`extract` reruns simple prediction itself.
 
 .. note::
     Uncertainty fields require a committee-trained model or another UQ-capable setup. See :doc:`active_learning`.

--- a/docs/getting_started/preparing_dataset.rst
+++ b/docs/getting_started/preparing_dataset.rst
@@ -69,11 +69,15 @@ Units and gradients
 Building a dataset from TeraChem outputs
 ----------------------------------------
 
-The repository includes :code:`scripts/picklizer.py` for grouping TeraChem output files into a pickle. Each entry in :code:`file_lists` is a dict pointing to per-structure files:
+The repository includes :code:`scripts/picklizer.py` for grouping TeraChem output files into a pickle. Each entry in :code:`file_lists` is a dict pointing to per-structure files. Run from the **repository root** and put :code:`scripts/` on :code:`sys.path` (it is not an installable package):
 
 .. code-block:: python
 
-    from scripts.picklizer import picklizer
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path("scripts").resolve()))
+    from picklizer import picklizer
 
     file_lists = [
         {

--- a/docs/getting_started/server_and_enerzymette.rst
+++ b/docs/getting_started/server_and_enerzymette.rst
@@ -42,11 +42,11 @@ Sending a request (client)
 
 .. code-block:: bash
 
-    enerzyme request -u http://127.0.0.1:5000 -f ORCA -i input.extinp.tmp -k FF01
+    enerzyme request -u 127.0.0.1:5000 -f ORCA -i input.extinp.tmp -k FF01
 
 Arguments:
 
-- :code:`-u` — server URL
+- :code:`-u` — server host:port (scheme is added by the client; do not pass :code:`http://`)
 - :code:`-f` — input format (:code:`ORCA` for external optimizer workflows)
 - :code:`-i` — input file path
 - :code:`-k` — model key (must match an active :code:`FF` ID in the model config)
@@ -58,7 +58,7 @@ Shutting down the server
 
 .. code-block:: bash
 
-    enerzyme kill -u http://127.0.0.1:5000
+    enerzyme kill -u 127.0.0.1:5000
 
 Sends a shutdown signal to the listening process.
 

--- a/docs/getting_started/training.rst
+++ b/docs/getting_started/training.rst
@@ -241,6 +241,6 @@ After training, the output directory typically contains:
 - :code:`config.yaml` — resolved configuration (**keep this for predict/simulate**)
 - :code:`processed_dataset_<hash>/` — preprocessed HDF5 cache
 - :code:`logs/` — training logs, metrics, early-stopping traces
-- :code:`FF01/` (or your model ID) — :code:`best/` and :code:`last/` checkpoints
+- :code:`FF01-<arch>/` (or your model ID + architecture) — :code:`model_best.pth` and :code:`model_last.pth`
 
 Use :code:`enerzyme/config/train.yaml` when you need multi-dataset Datahub, external models, EMA, Lightning multi-GPU, or pretraining paths.

--- a/docs/user_guide/concepts/configuration_system.rst
+++ b/docs/user_guide/concepts/configuration_system.rst
@@ -60,7 +60,11 @@ Override rules at inference
 Legacy vs current schema
 ------------------------
 
-Older configs use a flat :code:`Datahub` with :code:`compression:`; current configs use :code:`compressed:` and optional :code:`datasets:` for multi-dataset training. Both layouts are still accepted; new projects should follow :code:`enerzyme/config/train.yaml`.
+Older configs sometimes used a flat :code:`Datahub` with the legacy key :code:`compression:`.
+Current configs use :code:`compressed:` and optional :code:`datasets:` for multi-dataset training.
+Only :code:`compressed:` is read by :code:`SingleDataHub`; a bare :code:`compression:` key is
+ignored (and silently leaves the default :code:`compressed: true`). New projects should follow
+:code:`enerzyme/config/train.yaml`.
 
 Splitter configs similarly support:
 

--- a/docs/user_guide/concepts/configuration_system.rst
+++ b/docs/user_guide/concepts/configuration_system.rst
@@ -34,7 +34,7 @@ Training artifacts
 After :code:`enerzyme train -c train.yaml -o out/`:
 
 - :code:`out/config.yaml` — resolved configuration (use as :code:`-mc` for predict/simulate)
-- :code:`out/FFxx/` or :code:`out/FFxx_suffix/` — model checkpoints (:code:`best/`, :code:`last/`)
+- :code:`out/FFxx-<arch>[-suffix]/` — model checkpoints (:code:`model_best.pth`, :code:`model_last.pth`)
 - :code:`out/processed_dataset_<hash>/` — preprocessed HDF5 cache
 - :code:`out/logs/` — training logs
 

--- a/docs/user_guide/data/datahub_reference.rst
+++ b/docs/user_guide/data/datahub_reference.rst
@@ -127,6 +127,11 @@ Defined under :code:`transforms`, :code:`global_transforms`, or (advanced)
 - :code:`total_energy_normalization` — global mean/std on :code:`E`
 - :code:`energy_unit_conversion` — convert energy/force units into the training convention
 - :code:`uniform_qs_init` — write per-atom :code:`Q_init_a` / :code:`S_init_a` as :code:`Q/N` and :code:`S/N` for flow-matching init (registers those fields as features automatically). Place under :code:`global_transforms` (single-dataset :code:`transforms:` is remapped there) or per-dataset :code:`transforms:` / :code:`preprocessings`
+- :code:`xtb_qs_prior` — GFN2-xTB + xtbml Mulliken-style prior into the same :code:`Q_init_a` / :code:`S_init_a` keys (optional; requires :code:`tblite` with xtbml, e.g. :code:`pip install 'enerzyme[xtb]'`). Mutually exclusive with :code:`uniform_qs_init` and :code:`pyscf_nao_qs_prior`
+- :code:`pyscf_nao_qs_prior` — GPU4PySCF/PySCF NAO prior into :code:`Q_init_a` / :code:`S_init_a`. YAML must set :code:`xc` and :code:`basis` (no defaults). Optional :code:`use_gpu` (default true) needs :code:`gpu4pyscf`; CPU path uses :code:`pyscf` only (:code:`pip install 'enerzyme[pyscf_nao]'`). Mutually exclusive with the other Q/S priors
+- :code:`qs_delta` — overwrite :code:`Qa` / :code:`Sa` targets with residuals vs :code:`Q_init_a` / :code:`S_init_a`. Must share the same :code:`preprocessings` or :code:`global_transforms` block as exactly one prior hook so the prior exists before deltas; prediction inverse adds the prior back
+
+Enable **only one** of :code:`uniform_qs_init`, :code:`xtb_qs_prior`, or :code:`pyscf_nao_qs_prior` across preprocessings and global transforms — they all write the same prior fields.
 
 Cache invalidation
 ------------------

--- a/docs/user_guide/data/dataset_formats.rst
+++ b/docs/user_guide/data/dataset_formats.rst
@@ -63,11 +63,17 @@ a fallback for legacy databases without schema.
 TeraChem to pickle
 ------------------
 
-:code:`scripts/picklizer.py` groups TeraChem outputs:
+:code:`scripts/picklizer.py` groups TeraChem outputs. From the repository root, put
+:code:`scripts/` on :code:`sys.path` (it is not an installable package):
 
 .. code-block:: python
 
-    from scripts.picklizer import picklizer
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path("scripts").resolve()))
+    from picklizer import picklizer
+
     picklizer(file_lists, output="dataset.pkl", flavor="terachem", provide_Q=-1)
 
 Each :code:`file_lists` entry maps keys :code:`coord`, :code:`grad`, :code:`chrg`, :code:`dipole` to file paths. Gradients are converted from Ha/Bohr to Ha/Angstrom in the parser.

--- a/docs/user_guide/data/preprocessing_and_collect.rst
+++ b/docs/user_guide/data/preprocessing_and_collect.rst
@@ -50,3 +50,23 @@ Transform details
 
 :code:`total_energy_normalization`
     Global mean/variance normalization on total energy (use with care for relative energies).
+
+:code:`uniform_qs_init`
+    Splits total :code:`Q` / :code:`S` uniformly onto atoms as :code:`Q_init_a` / :code:`S_init_a` (flow or delta priors).
+
+:code:`xtb_qs_prior`
+    Runs GFN2-xTB + xtbml Mulliken populations per frame into :code:`Q_init_a` / :code:`S_init_a`.
+    Optional dependency: :code:`tblite` with xtbml (:code:`pip install 'enerzyme[xtb]'`).
+    Typical YAML: :code:`enabled: true`, optional :code:`max_scf_iter` (default 1).
+
+:code:`pyscf_nao_qs_prior`
+    Runs finite-step DFT + NAO populations into :code:`Q_init_a` / :code:`S_init_a`.
+    Requires :code:`xc` and :code:`basis` in YAML. Optional deps: :code:`pyscf` and, when
+    :code:`use_gpu: true`, :code:`gpu4pyscf` (install CUDA stack separately; core extra is
+    :code:`pip install 'enerzyme[pyscf_nao]'`).
+
+:code:`qs_delta`
+    Replaces :code:`Qa` / :code:`Sa` training targets with residuals against the prior.
+    Enable together with exactly one prior in the same transform block. At predict/metric
+    time, inverse transform restores full charges/spins using :code:`Q_init_a` / :code:`S_init_a`
+    copied from batch features.

--- a/docs/user_guide/integrations/bond_assignment.rst
+++ b/docs/user_guide/integrations/bond_assignment.rst
@@ -1,7 +1,7 @@
 Bond Assignment
 ===============
 
-:code:`enerzyme bond` assigns chemical bonds to PDB cluster structures, typically from `QuantumPDB <https://github.com/davidkastner/quantumPDB>`_ workflows.
+:code:`enerzyme bond` assigns chemical bonds to PDB cluster structures, typically from `QuantumPDB <https://github.com/hjkgrp/quantumPDB>`_ workflows.
 
 Command
 -------

--- a/docs/user_guide/integrations/server_mode.rst
+++ b/docs/user_guide/integrations/server_mode.rst
@@ -22,15 +22,15 @@ Client request:
 
 .. code-block:: bash
 
-    enerzyme request -u http://127.0.0.1:5000 -f ORCA -i input.extinp.tmp -k FF02
+    enerzyme request -u 127.0.0.1:5000 -f ORCA -i input.extinp.tmp -k FF02
 
-In shell mode the default :code:`model_key` is :code:`external` (omit :code:`-k` or pass :code:`-k external`).
+Pass :code:`-u` as host:port only (the client prepends :code:`http://`). In shell mode the default :code:`model_key` is :code:`external` (omit :code:`-k` or pass :code:`-k external`).
 
 Shutdown:
 
 .. code-block:: bash
 
-    enerzyme kill -u http://127.0.0.1:5000
+    enerzyme kill -u 127.0.0.1:5000
 
 Implementation
 --------------

--- a/docs/user_guide/models/architecture_catalog.rst
+++ b/docs/user_guide/models/architecture_catalog.rst
@@ -52,6 +52,7 @@ Internal architectures
 | E2Former-V2    | via      | via    | yes    | via         | SO2/EAAS +       |
 |                | readout  | readout|        | readout     | sparse Triton    |
 |                |          |        |        |             | attention        |
++----------------+----------+--------+--------+-------------+------------------+
 | E2Former-LSR   | via      | via    | yes    | via         | Fragment         |
 |                | readout  | readout|        | readout     | bipartite        |
 |                |          |        |        |             | long-range MP    |

--- a/docs/user_guide/models/checkpoints_resume.rst
+++ b/docs/user_guide/models/checkpoints_resume.rst
@@ -6,15 +6,29 @@ Training lifecycle is controlled by :code:`Trainer` options and checkpoint files
 Checkpoint layout
 -----------------
 
+Checkpoints are written **directly** in each model directory (no :code:`best/` or
+:code:`last/` subfolders). Filenames encode the preference and optional committee rank:
+
 .. code-block:: text
 
-    FF02_suffix/
-    ├── best/
-    │   └── model_best.pth
-    └── last/
-        └── model_last.pth
+    FF02-SpookyNet/
+    ├── model_best.pth
+    ├── model_last.pth
+    └── model_epoch=10.pth          # optional, when dump_interval > 0
 
-Committee models use :code:`model0.pth`, :code:`model1.pth`, ... under :code:`best/` and :code:`last/`.
+Committee members use a numeric rank in the filename prefix:
+
+.. code-block:: text
+
+    FF02-SpookyNet/
+    ├── model0_best.pth
+    ├── model0_last.pth
+    ├── model1_best.pth
+    └── model1_last.pth
+
+Lightning may also emit versioned names such as :code:`model_best-v1.pth`;
+:code:`get_pretrain_path` prefers the appropriate :code:`best` / :code:`last` file
+in that directory.
 
 Resume modes
 ------------
@@ -30,7 +44,9 @@ Implementation: :code:`enerzyme/tasks/trainer.py`.
 Pretraining
 -----------
 
-:code:`Modelhub.internal_FFs.FFxx.pretrain_path` points to a previous run directory. Enerzyme resolves :code:`best/` or explicit paths via :code:`get_pretrain_path`.
+:code:`Modelhub.internal_FFs.FFxx.pretrain_path` points to a previous run directory (or an
+explicit :code:`.pth` file). Enerzyme resolves :code:`model*_best.pth` / :code:`model*_last.pth`
+in that directory via :code:`get_pretrain_path` (preference :code:`best` or :code:`last`).
 
 Typical in iterative AL:
 

--- a/docs/user_guide/models/modelhub_reference.rst
+++ b/docs/user_guide/models/modelhub_reference.rst
@@ -48,10 +48,11 @@ Key fields
     Only active models are trained, loaded for predict/simulate, or served by :code:`listen`.
 
 :code:`suffix`
-    Appended to checkpoint directory names (:code:`FF02_19/`).
+    Appended to checkpoint directory names (e.g. :code:`FF02-SpookyNet-19/`).
 
 :code:`pretrain_path`
-    Directory with :code:`best/` or :code:`last/` weights to initialize training.
+    Previous run directory (or an explicit :code:`.pth` file) whose
+    :code:`model*_best.pth` / :code:`model*_last.pth` weights initialize training.
 
 :code:`build_params`
     Shared hyperparameters passed to all layers unless overridden in :code:`params`.
@@ -71,12 +72,13 @@ After training with :code:`-o out/`:
 
     out/
     ├── config.yaml
-    ├── FF02_19/
-    │   ├── best/model_best.pth
-    │   └── last/model_last.pth
+    ├── FF02-SpookyNet-19/
+    │   ├── model_best.pth
+    │   └── model_last.pth
     └── logs/
 
-For committees, expect :code:`model0`, :code:`model1`, ... under :code:`best/` and :code:`last/`.
+For committees, expect :code:`model0_best.pth`, :code:`model0_last.pth`, :code:`model1_best.pth`, …
+in the same model directory (no :code:`best/` / :code:`last/` subfolders).
 
 Multiple models
 ---------------

--- a/docs/user_guide/operations/reproducibility.rst
+++ b/docs/user_guide/operations/reproducibility.rst
@@ -19,7 +19,7 @@ Archive with each model
 Minimum artifact set:
 
 - :code:`config.yaml` from training output
-- :code:`best/` and optionally :code:`last/` checkpoints
+- :code:`model_best.pth` and optionally :code:`model_last.pth` (committee: :code:`model0_best.pth`, …)
 - Training :code:`train.yaml` (or Enerzymette-generated :code:`train.yaml` per iteration)
 - :code:`processed_dataset_<hash>/` or instructions to rebuild from raw pickle
 - Split index files if :code:`Splitter.save: true`

--- a/docs/user_guide/workflows/fragment_extraction.rst
+++ b/docs/user_guide/workflows/fragment_extraction.rst
@@ -10,7 +10,7 @@ Command
 
     enerzyme extract -c extract.yaml -o out/ -m model_dir/ -mc config.yaml [-s]
 
-:code:`-s` skips prediction if pickles already exist under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir`.
+:code:`-s` skips prediction and loads existing **simple-predict** pickles under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir` (from :code:`enerzyme predict ... -s`; metric-mode pickles are not compatible).
 
 Configuration
 -------------

--- a/docs/user_guide/workflows/fragment_extraction.rst
+++ b/docs/user_guide/workflows/fragment_extraction.rst
@@ -10,7 +10,7 @@ Command
 
     enerzyme extract -c extract.yaml -o out/ -m model_dir/ -mc config.yaml [-s]
 
-:code:`-s` skips prediction if pickles already exist in :code:`output_dir`.
+:code:`-s` skips prediction if pickles already exist under each dataset's :code:`processed_dataset_<hash>/` in :code:`output_dir`.
 
 Configuration
 -------------

--- a/docs/user_guide/workflows/prediction.rst
+++ b/docs/user_guide/workflows/prediction.rst
@@ -55,7 +55,9 @@ Outputs
 -------
 
 - Per-active-model prediction pickles :code:`{FF_ID}-prediction.pkl` under each dataset's
-  :code:`processed_dataset_<hash>/` inside :code:`output_dir` (Datahub :code:`preload_path`)
+  :code:`processed_dataset_<hash>/` inside :code:`output_dir` (Datahub :code:`preload_path`).
+  Metric mode writes evaluation columns; :code:`--simple_predict` / :code:`-s` writes the
+  raw :code:`y_pred` fields needed by :code:`enerzyme extract -s`
 - Summary CSV :code:`metric.csv` in :code:`output_dir` when :code:`Metric` is defined
 - Uncertainty columns when model supports them and :code:`non_target_features` is set
 

--- a/docs/user_guide/workflows/prediction.rst
+++ b/docs/user_guide/workflows/prediction.rst
@@ -54,8 +54,9 @@ Test set sources
 Outputs
 -------
 
-- Per-active-model prediction pickles under :code:`output_dir`
-- Summary CSV when :code:`Metric` is defined
+- Per-active-model prediction pickles :code:`{FF_ID}-prediction.pkl` under each dataset's
+  :code:`processed_dataset_<hash>/` inside :code:`output_dir` (Datahub :code:`preload_path`)
+- Summary CSV :code:`metric.csv` in :code:`output_dir` when :code:`Metric` is defined
 - Uncertainty columns when model supports them and :code:`non_target_features` is set
 
 Simple predict mode

--- a/enerzyme/collect.py
+++ b/enerzyme/collect.py
@@ -10,4 +10,6 @@ class FFCollect(object):
         self.out_dir = out_dir
         self.datahub = DataHub(dump_dir=out_dir, **config.Datahub)
         self.splitter = Splitter(**config.Trainer.Splitter)
-        self.splitter.split(self.datahub.data, preload_path=self.datahub.preload_path)
+        # Match FF / train: Splitter.get_split operates on feature FieldDatasets keyed by dataset name.
+        # (Splitter.split is a defaultdict attribute, not a method.)
+        self.splitter.get_split(self.datahub.features, preload_path=self.datahub.preload_path)

--- a/enerzyme/config/train.yaml
+++ b/enerzyme/config/train.yaml
@@ -38,6 +38,20 @@ Datahub:
         # uniform_qs_init: true                # optional: Q_init_a=Q/N, S_init_a=S/N (flow init).
         #   Prefer Datahub.global_transforms, or per-dataset transforms (→ preprocessings).
         #   Requires Q (and S for spin) in features.
+        # xtb_qs_prior:                        # optional: GFN2-xTB + xtbml prior into Q_init_a / S_init_a
+        #   enabled: true                      #   (max_scf_iter default 1; requires tblite with xtbml)
+        #   max_scf_iter: 1
+        # pyscf_nao_qs_prior:                  # optional: GPU4PySCF/PySCF NAO prior; xc and basis required
+        #   enabled: true
+        #   xc: wb97m-v
+        #   basis: def2-svp
+        #   max_scf_iter: 1
+        #   conv_tol: 1.0e-6
+        #   density_fit: true
+        #   use_gpu: true
+        # qs_delta: true                       # optional: overwrite Qa/Sa with residual vs Q_init_a/S_init_a
+        #   # Enable only one of uniform_qs_init / xtb_qs_prior / pyscf_nao_qs_prior with qs_delta
+        #   # in the same preprocessings or global_transforms block.
 Modelhub:
   internal_FFs:                             # force fields built in enerzyme
     FF01:                                   # force field ID

--- a/enerzyme/data/datahub.py
+++ b/enerzyme/data/datahub.py
@@ -13,12 +13,17 @@ from tqdm import tqdm
 from torch.utils.data import Dataset
 from .datatype import is_atomic, is_rounded, is_int, register_data_type
 from .transform import (
-    UniformSplitQSTransform,
-    parse_Za,
-    Transform,
-    wants_uniform_qs_init,
     EnergyUnitConversionTransform,
     NegativeGradientTransform,
+    PySCFNAOQSPriorTransform,
+    Transform,
+    UniformSplitQSTransform,
+    XTBQSPriorTransform,
+    parse_Za,
+    wants_pyscf_nao_qs_prior,
+    wants_qs_delta,
+    wants_uniform_qs_init,
+    wants_xtb_qs_prior,
 )
 from ..utils import YamlHandler, logger
 
@@ -471,9 +476,25 @@ class SingleDataHub:
         self._populate_uniform_qs_init = wants_uniform_qs_init(
             global_transforms
         ) or wants_uniform_qs_init(preprocessings)
+        self._populate_xtb_qs_prior = wants_xtb_qs_prior(
+            global_transforms
+        ) or wants_xtb_qs_prior(preprocessings)
+        self._populate_pyscf_nao_qs_prior = wants_pyscf_nao_qs_prior(
+            global_transforms
+        ) or wants_pyscf_nao_qs_prior(preprocessings)
         if self._populate_uniform_qs_init:
             self.feature_types = dict(self.feature_types)
             for _k in UniformSplitQSTransform.POPULATED_KEYS:
+                self.feature_types.setdefault(_k, _k)
+            self.data_types = self.feature_types | self.target_types
+        if self._populate_xtb_qs_prior:
+            self.feature_types = dict(self.feature_types)
+            for _k in XTBQSPriorTransform.POPULATED_KEYS:
+                self.feature_types.setdefault(_k, _k)
+            self.data_types = self.feature_types | self.target_types
+        if self._populate_pyscf_nao_qs_prior:
+            self.feature_types = dict(self.feature_types)
+            for _k in PySCFNAOQSPriorTransform.POPULATED_KEYS:
                 self.feature_types.setdefault(_k, _k)
             self.data_types = self.feature_types | self.target_types
         self.neighbor_list_type = neighbor_list
@@ -495,6 +516,35 @@ class SingleDataHub:
         self.hash = md5(datahub_str.encode("utf-8")).hexdigest()[:hash_length]
         self.preload_path = os.path.join(dump_dir, f"processed_dataset_{self.hash}")
         logger.info(f"Preload path {self.preload_path} is created")
+        _pre = preprocessings or {}
+        _glb = global_transforms or {}
+        _any_uniform = wants_uniform_qs_init(_pre) or wants_uniform_qs_init(_glb)
+        _any_xtb = wants_xtb_qs_prior(_pre) or wants_xtb_qs_prior(_glb)
+        _any_pyscf = wants_pyscf_nao_qs_prior(_pre) or wants_pyscf_nao_qs_prior(_glb)
+        _prior_slots = int(_any_uniform) + int(_any_xtb) + int(_any_pyscf)
+        if _prior_slots > 1:
+            raise ValueError(
+                "DataHub: do not combine uniform_qs_init, xtb_qs_prior, and pyscf_nao_qs_prior "
+                "across preprocessings and/or global_transforms; all populate Q_init_a / S_init_a "
+                "and a second HDF5 transform pass would overwrite the first."
+            )
+        if wants_qs_delta(_pre) and not (
+            wants_uniform_qs_init(_pre) or wants_xtb_qs_prior(_pre) or wants_pyscf_nao_qs_prior(_pre)
+        ):
+            raise ValueError(
+                "DataHub preprocessings: qs_delta is enabled but no Q/S prior transform "
+                "(uniform_qs_init, xtb_qs_prior, or pyscf_nao_qs_prior) in preprocessings. "
+                "Priors must be created in the same preprocessing pass before deltas "
+                "(preprocessing runs before global_transforms)."
+            )
+        if wants_qs_delta(_glb) and not (
+            wants_uniform_qs_init(_glb) or wants_xtb_qs_prior(_glb) or wants_pyscf_nao_qs_prior(_glb)
+        ):
+            raise ValueError(
+                "DataHub global_transforms: qs_delta requires a Q/S prior transform "
+                "(uniform_qs_init, xtb_qs_prior, or pyscf_nao_qs_prior) in the same "
+                "global_transforms block so Q_init_a / S_init_a exist before delta targets."
+            )
         self.preprocessing = Transform(preprocessings, self.preload_path)
         self.global_transform = Transform(global_transforms, self.preload_path)
         self.preprocessings = preprocessings
@@ -765,7 +815,11 @@ class SingleDataHub:
             elif (
                 is_atomic(k)
                 and k in UniformSplitQSTransform.POPULATED_KEYS
-                and self._populate_uniform_qs_init
+                and (
+                    self._populate_uniform_qs_init
+                    or self._populate_xtb_qs_prior
+                    or self._populate_pyscf_nao_qs_prior
+                )
             ):
                 continue
             elif is_atomic(k):

--- a/enerzyme/data/datahub.py
+++ b/enerzyme/data/datahub.py
@@ -28,14 +28,51 @@ from .transform import (
 from ..utils import YamlHandler, logger
 
 
+def _atomic_charges_from_atoms(atoms: Atoms) -> Any:
+    """Qa from calculator ``charges`` when present, else ASE ``initial_charges``."""
+    if atoms.calc is not None:
+        results = getattr(atoms.calc, "results", None) or {}
+        if "charges" in results:
+            return atoms.get_charges()
+        try:
+            return atoms.get_charges()
+        except Exception:
+            pass
+    if atoms.has("initial_charges"):
+        return atoms.get_initial_charges()
+    raise AttributeError(
+        "No atomic charges: calculator charges / get_charges() and "
+        "initial_charges are all unavailable"
+    )
+
+
+def _atomic_magmoms_from_atoms(atoms: Atoms) -> Any:
+    """Sa from calculator ``magmoms`` when present, else ASE ``initial_magmoms``."""
+    if atoms.calc is not None:
+        results = getattr(atoms.calc, "results", None) or {}
+        if "magmoms" in results:
+            return atoms.get_magnetic_moments()
+        try:
+            return atoms.get_magnetic_moments()
+        except Exception:
+            pass
+    if atoms.has("initial_magmoms"):
+        return atoms.get_initial_magnetic_moments()
+    raise AttributeError(
+        "No atomic magmoms: calculator magmoms / get_magnetic_moments() and "
+        "initial_magmoms are all unavailable"
+    )
+
+
 # Standard Enerzyme names → ASE Atoms accessors (calculator results / geometry).
 # ASE itself still stores calculator keys as energy/forces/dipole/charges/magmoms
 # and fairchem-style info keys charge/spin; this adapter only exposes standard names.
+# Qa/Sa prefer calculator populations, then fall back to ASE initial_* arrays.
 ASE_PROPERTY_METHODS: Dict[str, Callable[[Atoms], Any]] = {
     "E": lambda atoms: atoms.get_potential_energy(),
     "Fa": lambda atoms: atoms.get_forces(),
-    "Qa": lambda atoms: atoms.get_charges(),
-    "Sa": lambda atoms: atoms.get_magnetic_moments(),
+    "Qa": _atomic_charges_from_atoms,
+    "Sa": _atomic_magmoms_from_atoms,
     "M2": lambda atoms: atoms.get_dipole_moment(),
 }
 
@@ -63,23 +100,28 @@ _ASELMDB_FIXED_KEYS = _ASELMDB_GEOMETRY_KEYS | frozenset(ASE_PROPERTY_METHODS)
 
 
 def _probe_calculator_properties(atoms: Atoms) -> set:
-    """Discover calculator-backed fields from ``calc.results`` (fallback: accessors)."""
+    """Discover ASE-backed fields from ``calc.results``, accessors, or initial_*."""
     found: set = set()
-    if atoms.calc is None:
-        return found
-    results = getattr(atoms.calc, "results", None) or {}
-    for ase_key, std_key in _ASE_RESULTS_KEY_TO_STANDARD.items():
-        if ase_key in results:
-            found.add(std_key)
-    for prop, method in ASE_PROPERTY_METHODS.items():
-        if prop in found:
-            continue
-        try:
-            method(atoms)
-        except Exception as e:
-            logger.warning(f"Failed to get {prop} directly from calculator: {e}")
-        else:
-            found.add(prop)
+    if atoms.calc is not None:
+        results = getattr(atoms.calc, "results", None) or {}
+        for ase_key, std_key in _ASE_RESULTS_KEY_TO_STANDARD.items():
+            if ase_key in results:
+                found.add(std_key)
+        for prop, method in ASE_PROPERTY_METHODS.items():
+            if prop in found:
+                continue
+            try:
+                method(atoms)
+            except Exception as e:
+                logger.warning(f"Failed to get {prop} directly from calculator: {e}")
+            else:
+                found.add(prop)
+    # DBs without a calculator (or lacking charges/magmoms) can still expose
+    # populations via ASE initial arrays, e.g. BOS-TMC aselmdb.
+    if "Qa" not in found and atoms.has("initial_charges"):
+        found.add("Qa")
+    if "Sa" not in found and atoms.has("initial_magmoms"):
+        found.add("Sa")
     return found
 
 

--- a/enerzyme/data/transform.py
+++ b/enerzyme/data/transform.py
@@ -239,6 +239,8 @@ class XTBQSPriorTransform(BaseTransform):
         out_s: str = "S_init_a",
         max_scf_iter: int = 1,
         atomic_qs_fn: Optional[Callable[..., Tuple[Any, Any]]] = None,
+        preload_path: Optional[str] = None,
+        checkpoint_every: Optional[int] = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -252,6 +254,10 @@ class XTBQSPriorTransform(BaseTransform):
         self.out_q = out_q
         self.out_s = out_s
         self.max_scf_iter = int(max_scf_iter)
+        self.preload_path = preload_path
+        if checkpoint_every is None:
+            checkpoint_every = int(os.environ.get("XTB_QS_PRIOR_CKPT_EVERY", "32"))
+        self.checkpoint_every = max(0, int(checkpoint_every))
         if atomic_qs_fn is not None:
             self._atomic_qs_fn = atomic_qs_fn
         else:
@@ -261,6 +267,68 @@ class XTBQSPriorTransform(BaseTransform):
             check_xtbml_dependencies()
             self._atomic_qs_fn = atomic_Q_and_S_from_xtbml
         self.transform_type = "feature"
+
+    def _checkpoint_path(self) -> Optional[pathlib.Path]:
+        if not self.preload_path:
+            return None
+        return pathlib.Path(self.preload_path) / "xtb_qs_prior_ckpt.npz"
+
+    def _load_checkpoint(
+        self, n_frames: int, max_n: int
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        q_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        s_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        done = np.zeros(n_frames, dtype=bool)
+        ckpt_path = self._checkpoint_path()
+        if ckpt_path is None or not ckpt_path.is_file():
+            return q_block, s_block, done
+        try:
+            with np.load(ckpt_path) as ckpt:
+                if int(ckpt["n_frames"]) != n_frames or int(ckpt["max_n"]) != max_n:
+                    raise ValueError(
+                        f"shape mismatch n_frames/max_n "
+                        f"({ckpt['n_frames']},{ckpt['max_n']}) vs ({n_frames},{max_n})"
+                    )
+                if int(ckpt["max_scf_iter"]) != self.max_scf_iter:
+                    raise ValueError(
+                        f"max_scf_iter mismatch {ckpt['max_scf_iter']} vs {self.max_scf_iter}"
+                    )
+                q_block = np.asarray(ckpt["q_block"], dtype=np.float64)
+                s_block = np.asarray(ckpt["s_block"], dtype=np.float64)
+                done = np.asarray(ckpt["done"], dtype=bool)
+            logger.info(
+                "xtb_qs_prior: resumed checkpoint %s (%d / %d frames done)",
+                ckpt_path,
+                int(done.sum()),
+                n_frames,
+            )
+        except Exception as exc:
+            logger.warning("xtb_qs_prior: ignoring unusable checkpoint %s (%s)", ckpt_path, exc)
+            q_block = np.zeros((n_frames, max_n), dtype=np.float64)
+            s_block = np.zeros((n_frames, max_n), dtype=np.float64)
+            done = np.zeros(n_frames, dtype=bool)
+        return q_block, s_block, done
+
+    def _save_checkpoint(
+        self, q_block: np.ndarray, s_block: np.ndarray, done: np.ndarray
+    ) -> None:
+        ckpt_path = self._checkpoint_path()
+        if ckpt_path is None or self.checkpoint_every <= 0:
+            return
+        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        # np.savez_compressed appends ".npz" unless the path already ends with it.
+        # Do NOT use "*.npz.tmp" (becomes "*.npz.tmp.npz" and os.replace fails).
+        tmp_path = ckpt_path.with_name(f"{ckpt_path.stem}.tmp.npz")
+        np.savez_compressed(
+            tmp_path,
+            q_block=q_block,
+            s_block=s_block,
+            done=done,
+            n_frames=np.int64(q_block.shape[0]),
+            max_n=np.int64(q_block.shape[1]),
+            max_scf_iter=np.int64(self.max_scf_iter),
+        )
+        os.replace(tmp_path, ckpt_path)
 
     def transform(self, new_input: Dict[str, Iterable]) -> None:
         from ase import Atoms
@@ -283,12 +351,15 @@ class XTBQSPriorTransform(BaseTransform):
         s_flat = np.asarray(new_input[self.s_key][:], dtype=np.float64).ravel()
         q_len = max(len(q_flat), 1)
         s_len = max(len(s_flat), 1)
-        q_block = np.zeros((n_frames, max_n), dtype=np.float64)
-        s_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        q_block, s_block, done = self._load_checkpoint(n_frames, max_n)
         failures: List[int] = []
+        computed_since_ckpt = 0
         for i in tqdm(range(n_frames), desc="xtb_qs_prior"):
+            if done[i]:
+                continue
             n_atoms = int(n_arr[i % len(n_arr)])
             if n_atoms <= 0:
+                done[i] = True
                 continue
             # Za may be compressed to a single stoichiometry row.
             za_row = za[i % len(za)]
@@ -308,10 +379,18 @@ class XTBQSPriorTransform(BaseTransform):
                 qa, sa = _conserve_atomic_totals(qa, sa, n_atoms, q_tot, s_tot)
                 q_block[i, :n_atoms] = qa
                 s_block[i, :n_atoms] = sa
+                done[i] = True
+                computed_since_ckpt += 1
+                if (
+                    self.checkpoint_every > 0
+                    and computed_since_ckpt % self.checkpoint_every == 0
+                ):
+                    self._save_checkpoint(q_block, s_block, done)
             except Exception as e:
                 failures.append(i)
                 logger.error(f"xtb_qs_prior: frame {i} failed: {e}")
         if failures:
+            self._save_checkpoint(q_block, s_block, done)
             raise RuntimeError(
                 f"xtb_qs_prior: {len(failures)} / {n_frames} frames failed (indices {failures[:20]}"
                 f"{'...' if len(failures) > 20 else ''}); no silent fallback."
@@ -322,6 +401,9 @@ class XTBQSPriorTransform(BaseTransform):
             del new_input[self.out_s]
         new_input.create_dataset(self.out_q, data=q_block)
         new_input.create_dataset(self.out_s, data=s_block)
+        ckpt_path = self._checkpoint_path()
+        if ckpt_path is not None and ckpt_path.is_file():
+            ckpt_path.unlink()
         logger.info("xtb_qs_prior: wrote Q_init_a and S_init_a from xTB")
 
     def single_inverse_transform(self, new_output: Dict[str, Iterable], idx: int) -> None:
@@ -747,6 +829,8 @@ class Transform:
                     continue
                 kwargs = {k2: v2 for k2, v2 in v.items()} if isinstance(v, dict) else {}
                 kwargs.pop("enabled", None)
+                # Frame-level npz checkpoints live under the DataHub preload dir.
+                kwargs.setdefault("preload_path", preload_path)
                 self.xtb_qs_priors.append(XTBQSPriorTransform(**kwargs))
             if k == "pyscf_nao_qs_prior":
                 if v is False or v is None:

--- a/enerzyme/data/transform.py
+++ b/enerzyme/data/transform.py
@@ -1,6 +1,8 @@
 import os, pathlib
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from functools import partial
+from multiprocessing import get_context
 import joblib
 import pandas as pd
 import numpy as np
@@ -138,6 +140,447 @@ def wants_uniform_qs_init(transform_args: Optional[Dict]) -> bool:
     return True
 
 
+
+def wants_xtb_qs_prior(transform_args: Optional[Dict]) -> bool:
+    """True when ``xtb_qs_prior`` is enabled in a transforms dict."""
+    if not transform_args or "xtb_qs_prior" not in transform_args:
+        return False
+    v = transform_args["xtb_qs_prior"]
+    if v is False or v is None:
+        return False
+    if isinstance(v, dict) and v.get("enabled") is False:
+        return False
+    return True
+
+
+def wants_pyscf_nao_qs_prior(transform_args: Optional[Dict]) -> bool:
+    """True when ``pyscf_nao_qs_prior`` is enabled in a transforms dict."""
+    if not transform_args or "pyscf_nao_qs_prior" not in transform_args:
+        return False
+    v = transform_args["pyscf_nao_qs_prior"]
+    if v is False or v is None:
+        return False
+    if isinstance(v, dict) and v.get("enabled") is False:
+        return False
+    return True
+
+
+def wants_qs_delta(transform_args: Optional[Dict]) -> bool:
+    """True when ``qs_delta`` is enabled in a transforms dict."""
+    if not transform_args or "qs_delta" not in transform_args:
+        return False
+    v = transform_args["qs_delta"]
+    if v is False or v is None:
+        return False
+    if isinstance(v, dict) and v.get("enabled") is False:
+        return False
+    return True
+
+
+def _conserve_atomic_totals(
+    q_atom: np.ndarray,
+    s_atom: np.ndarray,
+    n_atoms: int,
+    q_tot: float,
+    s_tot: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    if n_atoms <= 0:
+        return q_atom, s_atom
+    q = np.asarray(q_atom[:n_atoms], dtype=np.float64).copy()
+    s = np.asarray(s_atom[:n_atoms], dtype=np.float64).copy()
+    dq = float(q_tot) - float(q.sum())
+    ds = float(s_tot) - float(s.sum())
+    inv = 1.0 / n_atoms
+    q += dq * inv
+    s += ds * inv
+    return q, s
+
+
+def _multiplicity_from_enerzyme_S(s_val: float) -> int:
+    """Dataset ``S`` is (multiplicity - 1); ASE/tblite use multiplicity in ``atoms.info['spin']``."""
+    return max(1, int(round(float(s_val) + 1.0)))
+
+
+def _pyscf_nao_qs_prior_worker(
+    task: Tuple[int, np.ndarray, np.ndarray, int, float, float, int, Callable[..., Tuple[Any, Any]]]
+) -> Tuple[int, Optional[np.ndarray], Optional[np.ndarray], Optional[str]]:
+    """Run one PySCF NAO prior task without touching parent HDF5 handles."""
+    from ase import Atoms
+
+    i, z_i, r_i, n_atoms, q_tot, s_tot, max_scf_iter, atomic_qs_fn = task
+    if n_atoms <= 0:
+        return i, np.zeros(0, dtype=np.float64), np.zeros(0, dtype=np.float64), None
+    try:
+        atoms = Atoms(numbers=np.asarray(z_i, dtype=int), positions=np.asarray(r_i, dtype=float))
+        atoms.info["charge"] = float(q_tot)
+        atoms.info["spin"] = _multiplicity_from_enerzyme_S(float(s_tot))
+        qa, sa = atomic_qs_fn(atoms, int(max_scf_iter))
+        qa = np.asarray(qa, dtype=np.float64).reshape(-1)
+        sa = np.asarray(sa, dtype=np.float64).reshape(-1)
+        if qa.size != n_atoms or sa.size != n_atoms:
+            raise ValueError(f"expected length {n_atoms}, got Qa {qa.size}, Sa {sa.size}")
+        qa, sa = _conserve_atomic_totals(qa, sa, n_atoms, q_tot, s_tot)
+        return i, qa, sa, None
+    except Exception as exc:
+        return i, None, None, repr(exc)
+
+
+class XTBQSPriorTransform(BaseTransform):
+    """xTB Mulliken-style per-atom Q/S prior into ``Q_init_a`` / ``S_init_a`` (HDF5 cache only)."""
+
+    POPULATED_KEYS = frozenset({"Q_init_a", "S_init_a"})
+
+    def __init__(
+        self,
+        q_key: str = "Q",
+        s_key: str = "S",
+        n_key: str = "N",
+        out_q: str = "Q_init_a",
+        out_s: str = "S_init_a",
+        max_scf_iter: int = 1,
+        atomic_qs_fn: Optional[Callable[..., Tuple[Any, Any]]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("module_path", None)
+        if kwargs:
+            logger.warning("XTBQSPriorTransform: ignoring unrecognized keys %s", sorted(kwargs))
+        super().__init__(major_key=out_q)
+        self.q_key = q_key
+        self.s_key = s_key
+        self.n_key = n_key
+        self.out_q = out_q
+        self.out_s = out_s
+        self.max_scf_iter = int(max_scf_iter)
+        if atomic_qs_fn is not None:
+            self._atomic_qs_fn = atomic_qs_fn
+        else:
+            from ..qm.xtb_population.deps import check_xtbml_dependencies
+            from ..qm.xtb_population.atomic_populations import atomic_Q_and_S_from_xtbml
+
+            check_xtbml_dependencies()
+            self._atomic_qs_fn = atomic_Q_and_S_from_xtbml
+        self.transform_type = "feature"
+
+    def transform(self, new_input: Dict[str, Iterable]) -> None:
+        from ase import Atoms
+
+        required = ("Ra", "Za", self.n_key, self.q_key, self.s_key)
+        for rk in required:
+            if rk not in new_input:
+                raise KeyError(f"xtb_qs_prior: missing required dataset '{rk}'")
+        za = np.asarray(new_input["Za"])
+        # Compressed datasets may store a single stoichiometry row (1-D or 2-D with one frame).
+        if za.ndim == 1:
+            za = za.reshape(1, -1)
+        elif za.ndim != 2:
+            raise ValueError(f"xtb_qs_prior: Za must be 1-D or 2-D, got shape {za.shape}")
+        # Ra is never compressed; N/Q/S may be shared across frames when compressed.
+        n_frames = len(new_input["Ra"])
+        max_n = int(za.shape[1])
+        n_arr = np.asarray(new_input[self.n_key][:], dtype=np.int64).ravel()
+        q_flat = np.asarray(new_input[self.q_key][:], dtype=np.float64).ravel()
+        s_flat = np.asarray(new_input[self.s_key][:], dtype=np.float64).ravel()
+        q_len = max(len(q_flat), 1)
+        s_len = max(len(s_flat), 1)
+        q_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        s_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        failures: List[int] = []
+        for i in tqdm(range(n_frames), desc="xtb_qs_prior"):
+            n_atoms = int(n_arr[i % len(n_arr)])
+            if n_atoms <= 0:
+                continue
+            # Za may be compressed to a single stoichiometry row.
+            za_row = za[i % len(za)]
+            z_i = np.asarray(za_row[:n_atoms], dtype=int)
+            r_i = np.asarray(new_input["Ra"][i, :n_atoms], dtype=float)
+            q_tot = float(q_flat[i % q_len])
+            s_tot = float(s_flat[i % s_len])
+            atoms = Atoms(numbers=z_i, positions=r_i)
+            atoms.info["charge"] = q_tot
+            atoms.info["spin"] = _multiplicity_from_enerzyme_S(s_tot)
+            try:
+                qa, sa = self._atomic_qs_fn(atoms, self.max_scf_iter)
+                qa = np.asarray(qa, dtype=np.float64).reshape(-1)
+                sa = np.asarray(sa, dtype=np.float64).reshape(-1)
+                if qa.size != n_atoms or sa.size != n_atoms:
+                    raise ValueError(f"expected length {n_atoms}, got Qa {qa.size}, Sa {sa.size}")
+                qa, sa = _conserve_atomic_totals(qa, sa, n_atoms, q_tot, s_tot)
+                q_block[i, :n_atoms] = qa
+                s_block[i, :n_atoms] = sa
+            except Exception as e:
+                failures.append(i)
+                logger.error(f"xtb_qs_prior: frame {i} failed: {e}")
+        if failures:
+            raise RuntimeError(
+                f"xtb_qs_prior: {len(failures)} / {n_frames} frames failed (indices {failures[:20]}"
+                f"{'...' if len(failures) > 20 else ''}); no silent fallback."
+            )
+        if self.out_q in new_input:
+            del new_input[self.out_q]
+        if self.out_s in new_input:
+            del new_input[self.out_s]
+        new_input.create_dataset(self.out_q, data=q_block)
+        new_input.create_dataset(self.out_s, data=s_block)
+        logger.info("xtb_qs_prior: wrote Q_init_a and S_init_a from xTB")
+
+    def single_inverse_transform(self, new_output: Dict[str, Iterable], idx: int) -> None:
+        pass
+
+
+class PySCFNAOQSPriorTransform(BaseTransform):
+    """GPU4PySCF/PySCF NAO per-atom Q/S prior into ``Q_init_a`` / ``S_init_a`` (HDF5 cache only).
+
+    DFT settings are taken from YAML / constructor kwargs (no built-in xc or basis).
+    Required when not injecting ``atomic_qs_fn``: ``xc``, ``basis``.
+    Optional: ``max_scf_iter``, ``conv_tol``, ``density_fit``, ``use_gpu``, ``verbose``, ``n_processes``.
+    """
+
+    POPULATED_KEYS = frozenset({"Q_init_a", "S_init_a"})
+
+    def __init__(
+        self,
+        q_key: str = "Q",
+        s_key: str = "S",
+        n_key: str = "N",
+        out_q: str = "Q_init_a",
+        out_s: str = "S_init_a",
+        max_scf_iter: int = 1,
+        xc: Optional[str] = None,
+        basis: Optional[str] = None,
+        conv_tol: float = 1e-6,
+        density_fit: bool = True,
+        use_gpu: bool = True,
+        verbose: int = 0,
+        n_processes: int = 1,
+        atomic_qs_fn: Optional[Callable[..., Tuple[Any, Any]]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("module_path", None)
+        if kwargs:
+            logger.warning("PySCFNAOQSPriorTransform: ignoring unrecognized keys %s", sorted(kwargs))
+        super().__init__(major_key=out_q)
+        self.q_key = q_key
+        self.s_key = s_key
+        self.n_key = n_key
+        self.out_q = out_q
+        self.out_s = out_s
+        self.max_scf_iter = int(max_scf_iter)
+        self.xc = xc
+        self.basis = basis
+        self.conv_tol = float(conv_tol)
+        self.density_fit = bool(density_fit)
+        self.use_gpu = bool(use_gpu)
+        self.verbose = int(verbose)
+        self.n_processes = int(n_processes)
+        if atomic_qs_fn is not None:
+            self._atomic_qs_fn = atomic_qs_fn
+        else:
+            if not xc or not basis:
+                raise ValueError(
+                    "pyscf_nao_qs_prior: 'xc' and 'basis' are required in YAML when "
+                    "atomic_qs_fn is not set (no default functional or basis group)."
+                )
+            from ..qm.pyscf_nao_population.deps import check_pyscf_nao_dependencies
+            from ..qm.pyscf_nao_population.atomic_populations import atomic_Q_and_S_from_pyscf_nao
+
+            check_pyscf_nao_dependencies(use_gpu=self.use_gpu)
+            self._atomic_qs_fn = partial(
+                atomic_Q_and_S_from_pyscf_nao,
+                xc=str(xc),
+                basis=str(basis),
+                conv_tol=self.conv_tol,
+                density_fit=self.density_fit,
+                use_gpu=self.use_gpu,
+                verbose=self.verbose,
+            )
+        self.transform_type = "feature"
+
+    def transform(self, new_input: Dict[str, Iterable]) -> None:
+        required = ("Ra", "Za", self.n_key, self.q_key, self.s_key)
+        for rk in required:
+            if rk not in new_input:
+                raise KeyError(f"pyscf_nao_qs_prior: missing required dataset '{rk}'")
+        za = np.asarray(new_input["Za"])
+        if za.ndim == 1:
+            za = za.reshape(1, -1)
+        elif za.ndim != 2:
+            raise ValueError(f"pyscf_nao_qs_prior: Za must be 1-D or 2-D, got shape {za.shape}")
+        # Ra is never compressed; N/Q/S may be shared across frames when compressed.
+        n_frames = len(new_input["Ra"])
+        max_n = int(za.shape[1])
+        n_arr = np.asarray(new_input[self.n_key][:], dtype=np.int64).ravel()
+        q_flat = np.asarray(new_input[self.q_key][:], dtype=np.float64).ravel()
+        s_flat = np.asarray(new_input[self.s_key][:], dtype=np.float64).ravel()
+        q_len = max(len(q_flat), 1)
+        s_len = max(len(s_flat), 1)
+        q_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        s_block = np.zeros((n_frames, max_n), dtype=np.float64)
+        failures: List[int] = []
+        tasks = []
+        za_len = len(za)
+        for i in range(n_frames):
+            n_atoms = int(n_arr[i % len(n_arr)])
+            if n_atoms <= 0:
+                tasks.append(
+                    (
+                        i,
+                        np.zeros(0, dtype=int),
+                        np.zeros((0, 3), dtype=np.float64),
+                        n_atoms,
+                        0.0,
+                        0.0,
+                        self.max_scf_iter,
+                        self._atomic_qs_fn,
+                    )
+                )
+                continue
+            za_row = za[i % za_len]
+            z_i = np.asarray(za_row[:n_atoms], dtype=int)
+            r_i = np.asarray(new_input["Ra"][i, :n_atoms], dtype=float)
+            q_tot = float(q_flat[i % q_len])
+            s_tot = float(s_flat[i % s_len])
+            tasks.append((i, z_i, r_i, n_atoms, q_tot, s_tot, self.max_scf_iter, self._atomic_qs_fn))
+
+        n_processes = max(1, self.n_processes)
+        if n_processes == 1:
+            results = (
+                _pyscf_nao_qs_prior_worker(task)
+                for task in tqdm(tasks, desc="pyscf_nao_qs_prior")
+            )
+            for i, qa, sa, error in results:
+                if error is not None:
+                    failures.append(i)
+                    logger.error(f"pyscf_nao_qs_prior: frame {i} failed: {error}")
+                    continue
+                n_atoms = int(n_arr[i % len(n_arr)])
+                q_block[i, :n_atoms] = qa
+                s_block[i, :n_atoms] = sa
+        else:
+            logger.info(f"pyscf_nao_qs_prior: running with {n_processes} processes (spawn)")
+            # CUDA contexts are not fork-safe. Use spawn so each worker initializes
+            # GPU4PySCF/CuPy from a clean interpreter instead of inheriting parent GPU state.
+            ctx = get_context("spawn")
+            with ctx.Pool(n_processes) as pool:
+                results = pool.imap(_pyscf_nao_qs_prior_worker, tasks)
+                for i, qa, sa, error in tqdm(results, total=len(tasks), desc="pyscf_nao_qs_prior"):
+                    if error is not None:
+                        failures.append(i)
+                        logger.error(f"pyscf_nao_qs_prior: frame {i} failed: {error}")
+                        continue
+                    n_atoms = int(n_arr[i % len(n_arr)])
+                    q_block[i, :n_atoms] = qa
+                    s_block[i, :n_atoms] = sa
+        if failures:
+            raise RuntimeError(
+                f"pyscf_nao_qs_prior: {len(failures)} / {n_frames} frames failed (indices {failures[:20]}"
+                f"{'...' if len(failures) > 20 else ''}); no silent fallback."
+            )
+        if self.out_q in new_input:
+            del new_input[self.out_q]
+        if self.out_s in new_input:
+            del new_input[self.out_s]
+        new_input.create_dataset(self.out_q, data=q_block)
+        new_input.create_dataset(self.out_s, data=s_block)
+        logger.info("pyscf_nao_qs_prior: wrote Q_init_a and S_init_a from PySCF NAO")
+
+    def single_inverse_transform(self, new_output: Dict[str, Iterable], idx: int) -> None:
+        pass
+
+
+class QSDeltaTransform(BaseTransform):
+    """In-place atomic delta transform: ``Qa`` / ``Sa`` = target minus prior (HDF5 cache only).
+
+    Forward runs only after ``Q_init_a`` / ``S_init_a`` exist (``Transform.transform`` order:
+    all ``uniform_qs_init``, then all ``xtb_qs_prior`` / ``pyscf_nao_qs_prior``, then all
+    ``qs_delta`` — YAML key order within each group does not change this).
+
+    NSE heads still output ``Qa`` / ``Sa``. To keep loss computation aligned with those output
+    names, this transform overwrites the loaded ``Qa`` / ``Sa`` targets with residual labels.
+    ``single_inverse_transform`` maps predicted residuals back to full ``Qa`` / ``Sa`` in place by
+    adding the prior for metrics and comparison to NBO references. Requires ``Q_init_a`` /
+    ``S_init_a`` on the same dict (see ``_decorate_batch_output`` copying from batch features).
+    """
+
+    POPULATED_KEYS = frozenset()
+
+    def __init__(
+        self,
+        qa_key: str = "Qa",
+        sa_key: str = "Sa",
+        q_init_key: str = "Q_init_a",
+        s_init_key: str = "S_init_a",
+        n_key: str = "N",
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("out_q", None)
+        kwargs.pop("out_s", None)
+        if kwargs:
+            logger.warning("QSDeltaTransform: ignoring unrecognized keys %s", sorted(kwargs))
+        super().__init__(major_key=qa_key)
+        self.qa_key = qa_key
+        self.sa_key = sa_key
+        self.q_init_key = q_init_key
+        self.s_init_key = s_init_key
+        self.n_key = n_key
+        self.transform_type = "target"
+
+    def transform(self, new_input: Dict[str, Iterable]) -> None:
+        need = (self.qa_key, self.sa_key, self.q_init_key, self.s_init_key, self.n_key, "Ra", "Za")
+        for k in need:
+            if k not in new_input:
+                raise KeyError(f"qs_delta: missing '{k}'")
+        # Ra is never compressed; N may be shared across frames when compressed.
+        n_frames = len(new_input["Ra"])
+        za = np.asarray(new_input["Za"])
+        if za.ndim == 1:
+            max_n = int(za.shape[0])
+        else:
+            max_n = int(za.shape[1])
+        n_arr = np.asarray(new_input[self.n_key][:], dtype=np.int64).ravel()
+        dq = np.zeros((n_frames, max_n), dtype=np.float64)
+        ds = np.zeros((n_frames, max_n), dtype=np.float64)
+        for i in range(n_frames):
+            n_atoms = int(n_arr[i % len(n_arr)])
+            if n_atoms <= 0:
+                continue
+            qa = np.asarray(new_input[self.qa_key][i, :n_atoms], dtype=np.float64)
+            sa = np.asarray(new_input[self.sa_key][i, :n_atoms], dtype=np.float64)
+            q0 = np.asarray(new_input[self.q_init_key][i, :n_atoms], dtype=np.float64)
+            s0 = np.asarray(new_input[self.s_init_key][i, :n_atoms], dtype=np.float64)
+            dq[i, :n_atoms] = qa - q0
+            ds[i, :n_atoms] = sa - s0
+        del new_input[self.qa_key]
+        del new_input[self.sa_key]
+        new_input.create_dataset(self.qa_key, data=dq)
+        new_input.create_dataset(self.sa_key, data=ds)
+        logger.info("qs_delta: overwrote Qa and Sa with residual targets")
+
+    def single_inverse_transform(self, new_output: Dict[str, Iterable], idx: int) -> None:
+        if self.qa_key not in new_output or self.sa_key not in new_output:
+            return
+        if self.q_init_key not in new_output or self.s_init_key not in new_output:
+            raise KeyError(
+                f"qs_delta inverse_transform: need '{self.q_init_key}' and '{self.s_init_key}' "
+                f"alongside '{self.qa_key}' / '{self.sa_key}' (they are copied from batch features in "
+                "_decorate_batch_output when present)."
+            )
+        dq = np.asarray(new_output[self.qa_key][idx], dtype=np.float64).reshape(-1)
+        ds = np.asarray(new_output[self.sa_key][idx], dtype=np.float64).reshape(-1)
+        q0 = np.asarray(new_output[self.q_init_key][idx], dtype=np.float64).reshape(-1)
+        s0 = np.asarray(new_output[self.s_init_key][idx], dtype=np.float64).reshape(-1)
+        n = dq.shape[0]
+        if q0.shape[0] < n or s0.shape[0] < n:
+            raise ValueError(
+                f"qs_delta inverse: prior length {q0.shape[0]} / {s0.shape[0]} < delta length {n}"
+            )
+        new_output[self.qa_key][idx] = dq + q0[:n]
+        new_output[self.sa_key][idx] = ds + s0[:n]
+
+
+
 class UniformSplitQSTransform(BaseTransform):
     """Per-frame uniform split of total charge Q and spin S onto atoms: Q_init_a = Q/N, S_init_a = S/N.
 
@@ -263,6 +706,9 @@ class Transform:
         self.scales = []
         self.normalizations = []
         self.uniform_qs_inits: List[UniformSplitQSTransform] = []
+        self.xtb_qs_priors: List[XTBQSPriorTransform] = []
+        self.pyscf_nao_qs_priors: List[PySCFNAOQSPriorTransform] = []
+        self.qs_deltas: List[QSDeltaTransform] = []
         if transform_args is None:
             return
         for k, v in transform_args.items():
@@ -294,6 +740,42 @@ class Transform:
                 kwargs = {k2: v2 for k2, v2 in v.items()} if isinstance(v, dict) else {}
                 kwargs.pop("enabled", None)
                 self.uniform_qs_inits.append(UniformSplitQSTransform(**kwargs))
+            if k == "xtb_qs_prior":
+                if v is False or v is None:
+                    continue
+                if isinstance(v, dict) and v.get("enabled") is False:
+                    continue
+                kwargs = {k2: v2 for k2, v2 in v.items()} if isinstance(v, dict) else {}
+                kwargs.pop("enabled", None)
+                self.xtb_qs_priors.append(XTBQSPriorTransform(**kwargs))
+            if k == "pyscf_nao_qs_prior":
+                if v is False or v is None:
+                    continue
+                if isinstance(v, dict) and v.get("enabled") is False:
+                    continue
+                kwargs = {k2: v2 for k2, v2 in v.items()} if isinstance(v, dict) else {}
+                kwargs.pop("enabled", None)
+                self.pyscf_nao_qs_priors.append(PySCFNAOQSPriorTransform(**kwargs))
+            if k == "qs_delta":
+                if v is False or v is None:
+                    continue
+                if isinstance(v, dict) and v.get("enabled") is False:
+                    continue
+                kwargs = {k2: v2 for k2, v2 in v.items()} if isinstance(v, dict) else {}
+                kwargs.pop("enabled", None)
+                self.qs_deltas.append(QSDeltaTransform(**kwargs))
+
+        _prior_count = (
+            bool(self.uniform_qs_inits)
+            + bool(self.xtb_qs_priors)
+            + bool(self.pyscf_nao_qs_priors)
+        )
+        if _prior_count > 1:
+            raise ValueError(
+                "Transform: enable only one of uniform_qs_init, xtb_qs_prior, or "
+                "pyscf_nao_qs_prior; all write Q_init_a / S_init_a and a later stage would "
+                "overwrite the earlier without warning."
+            )
 
     def transform(self, raw_input: Dict):
         for shift in self.shifts:
@@ -302,10 +784,26 @@ class Transform:
             scale.transform(raw_input)
         for normalization in self.normalizations:
             normalization.transform(raw_input)
+        # Q/S priors before deltas so Q_init_a / S_init_a exist when computing residuals
         for u in self.uniform_qs_inits:
             u.transform(raw_input)
+        for x in self.xtb_qs_priors:
+            x.transform(raw_input)
+        for p in self.pyscf_nao_qs_priors:
+            p.transform(raw_input)
+        for d in self.qs_deltas:
+            d.transform(raw_input)
 
     def inverse_transform(self, raw_output: Dict, selected_indices: Optional[Iterable[int]]=None):
+        # Reverse of forward: undo deltas first, then energy-related inverses
+        for d in reversed(self.qs_deltas):
+            d.inverse_transform(raw_output, selected_indices)
+        for x in reversed(self.xtb_qs_priors):
+            x.inverse_transform(raw_output, selected_indices)
+        for p in reversed(self.pyscf_nao_qs_priors):
+            p.inverse_transform(raw_output, selected_indices)
+        for u in reversed(self.uniform_qs_inits):
+            u.inverse_transform(raw_output, selected_indices)
         for normalization in self.normalizations:
             normalization.inverse_transform(raw_output, selected_indices)
         for scale in self.scales:

--- a/enerzyme/qm/pyscf_nao_population/__init__.py
+++ b/enerzyme/qm/pyscf_nao_population/__init__.py
@@ -1,0 +1,13 @@
+"""GPU4PySCF / PySCF NAO per-atom charge/spin priors for Enerzyme preprocessing."""
+
+from .deps import check_pyscf_nao_dependencies
+
+__all__ = ["check_pyscf_nao_dependencies", "atomic_Q_and_S_from_pyscf_nao"]
+
+
+def atomic_Q_and_S_from_pyscf_nao(*args, **kwargs):
+    """Run DFT + NAO populations; loads heavy deps on first use."""
+    check_pyscf_nao_dependencies()
+    from .atomic_populations import atomic_Q_and_S_from_pyscf_nao as _fn
+
+    return _fn(*args, **kwargs)

--- a/enerzyme/qm/pyscf_nao_population/atomic_populations.py
+++ b/enerzyme/qm/pyscf_nao_population/atomic_populations.py
@@ -1,0 +1,87 @@
+"""ASE + GPU4PySCF DFT + PySCF NAO population: per-atom ``Qa`` / ``Sa`` priors.
+
+``atoms.info`` uses:
+
+- ``charge``: total molecular charge (e), same convention as OMol / xTB helpers.
+- ``spin``: spin multiplicity M (2S+1), integer ≥ 1 (default 1).
+
+All DFT settings (``xc``, ``basis``, ``conv_tol``, ``density_fit``, ``use_gpu``) are
+caller-supplied; there are no hidden functional/basis defaults in this module.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from ase.units import Bohr
+from pyscf import gto
+
+from .gpu_dft import run_dft
+from .nao_population import nao_Qa_Sa_from_mf
+
+if TYPE_CHECKING:
+    from ase import Atoms
+    from pyscf.gto import Mole
+
+
+def _read_charge_spin(atoms: Atoms) -> tuple[int, int]:
+    charge = float(atoms.info.get("charge", 0.0))
+    mult = int(atoms.info.get("spin", 1))
+    if mult < 1:
+        raise ValueError("atoms.info['spin'] (multiplicity) must be >= 1")
+    return int(round(charge)), mult
+
+
+def atoms_to_mol(
+    atoms: Atoms,
+    *,
+    basis: str,
+    charge: int | None = None,
+    multiplicity: int | None = None,
+) -> Mole:
+    """Build a PySCF molecule from ASE atoms."""
+    if charge is None or multiplicity is None:
+        q, m = _read_charge_spin(atoms)
+        charge = q if charge is None else charge
+        multiplicity = m if multiplicity is None else multiplicity
+
+    symbols = atoms.get_chemical_symbols()
+    positions = np.asarray(atoms.get_positions(wrap=False), dtype=float) / Bohr
+    atom_lines = [
+        f"{sym} {pos[0]:.12f} {pos[1]:.12f} {pos[2]:.12f}"
+        for sym, pos in zip(symbols, positions, strict=True)
+    ]
+    spin = max(0, int(multiplicity) - 1)
+    return gto.M(
+        atom="; ".join(atom_lines),
+        basis=basis,
+        charge=int(charge),
+        spin=spin,
+        verbose=0,
+    )
+
+
+def atomic_Q_and_S_from_pyscf_nao(
+    atoms: Atoms,
+    max_scf_iter: int,
+    *,
+    xc: str,
+    basis: str,
+    conv_tol: float,
+    density_fit: bool,
+    use_gpu: bool,
+    verbose: int = 0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run finite-step GPU4PySCF (or CPU) DFT and return NAO-based ``Qa``, ``Sa``."""
+    mol = atoms_to_mol(atoms, basis=basis)
+    mf = run_dft(
+        mol,
+        xc=xc,
+        max_cycle=int(max_scf_iter),
+        conv_tol=float(conv_tol),
+        density_fit=bool(density_fit),
+        verbose=int(verbose),
+        use_gpu=bool(use_gpu),
+    )
+    qa, sa = nao_Qa_Sa_from_mf(mol, mf)
+    return np.asarray(qa, dtype=float).reshape(-1), np.asarray(sa, dtype=float).reshape(-1)

--- a/enerzyme/qm/pyscf_nao_population/deps.py
+++ b/enerzyme/qm/pyscf_nao_population/deps.py
@@ -1,0 +1,25 @@
+"""Runtime dependency checks for GPU4PySCF / PySCF NAO atomic population helpers."""
+
+
+def check_pyscf_nao_dependencies(*, use_gpu: bool = True) -> None:
+    """Verify packages needed for ``pyscf_nao_qs_prior`` preprocessing."""
+    try:
+        import ase  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "pyscf_nao_qs_prior requires ASE. Install with: pip install ase"
+        ) from exc
+    try:
+        import pyscf  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "pyscf_nao_qs_prior requires PySCF. Install with: pip install pyscf"
+        ) from exc
+    if use_gpu:
+        try:
+            import gpu4pyscf  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "pyscf_nao_qs_prior requires gpu4pyscf when use_gpu is true. "
+                "Install gpu4pyscf for your CUDA stack or set use_gpu: false in YAML."
+            ) from exc

--- a/enerzyme/qm/pyscf_nao_population/gpu_dft.py
+++ b/enerzyme/qm/pyscf_nao_population/gpu_dft.py
@@ -1,0 +1,105 @@
+"""GPU4PySCF finite-step DFT driver; returns a CPU PySCF SCF object for post-processing."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyscf.gto import Mole
+    from pyscf.scf.hf import SCF
+
+XcLike = str
+
+
+def run_gpu_dft(
+    mol: Mole,
+    *,
+    xc: XcLike,
+    max_cycle: int,
+    conv_tol: float,
+    density_fit: bool,
+    verbose: int,
+) -> SCF:
+    """Run RKS (singlet) or UKS (open-shell) on GPU; transfer the result to CPU."""
+    from gpu4pyscf import dft
+
+    spin = int(mol.spin)
+    if spin == 0:
+        mf = dft.rks.RKS(mol, xc=xc)
+    else:
+        mf = dft.uks.UKS(mol, xc=xc)
+
+    if density_fit:
+        mf = mf.density_fit()
+
+    mf = mf.to_gpu()
+    mf.max_cycle = int(max_cycle)
+    mf.conv_tol = float(conv_tol)
+    mf.verbose = int(verbose)
+    mf.kernel()
+    return mf.to_cpu()
+
+
+def run_cpu_dft(
+    mol: Mole,
+    *,
+    xc: XcLike,
+    max_cycle: int,
+    conv_tol: float,
+    density_fit: bool,
+    verbose: int,
+) -> SCF:
+    """CPU PySCF fallback when GPU is unavailable."""
+    from pyscf import dft
+
+    spin = int(mol.spin)
+    if spin == 0:
+        mf = dft.RKS(mol, xc=xc)
+    else:
+        mf = dft.UKS(mol, xc=xc)
+
+    if density_fit:
+        mf = mf.density_fit()
+
+    mf.max_cycle = int(max_cycle)
+    mf.conv_tol = float(conv_tol)
+    mf.verbose = int(verbose)
+    mf.kernel()
+    return mf
+
+
+def run_dft(
+    mol: Mole,
+    *,
+    xc: XcLike,
+    max_cycle: int,
+    conv_tol: float,
+    density_fit: bool,
+    verbose: int,
+    use_gpu: bool,
+) -> SCF:
+    if use_gpu:
+        try:
+            return run_gpu_dft(
+                mol,
+                xc=xc,
+                max_cycle=max_cycle,
+                conv_tol=conv_tol,
+                density_fit=density_fit,
+                verbose=verbose,
+            )
+        except Exception as exc:
+            import warnings
+
+            warnings.warn(
+                f"GPU4PySCF failed ({exc!r}); falling back to CPU PySCF.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    return run_cpu_dft(
+        mol,
+        xc=xc,
+        max_cycle=max_cycle,
+        conv_tol=conv_tol,
+        density_fit=density_fit,
+        verbose=verbose,
+    )

--- a/enerzyme/qm/pyscf_nao_population/nao_population.py
+++ b/enerzyme/qm/pyscf_nao_population/nao_population.py
@@ -1,0 +1,62 @@
+"""PySCF natural atomic orbital (NAO) Mulliken population on a converged or partial SCF density."""
+from __future__ import annotations
+
+from functools import reduce
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pyscf import scf
+from pyscf.lo import orth
+from pyscf.scf import hf
+
+if TYPE_CHECKING:
+    from pyscf.gto import Mole
+    from pyscf.scf.hf import SCF
+
+
+def _overlap(mf: SCF) -> np.ndarray:
+    return mf.get_ovlp()
+
+
+def _nao_ao_populations_per_atom(mol: Mole, mf: SCF, dm: np.ndarray, s: np.ndarray) -> np.ndarray:
+    """Sum NAO-basis Mulliken AO populations per atom for one spin density matrix."""
+    orth_coeff = orth.orth_ao(mf, "nao", s=s)
+    c_inv = np.dot(orth_coeff.conj().T, s)
+    dm_t = reduce(np.dot, (c_inv, dm, c_inv.T.conj()))
+    pop, _ = hf.mulliken_pop(mol, dm_t, np.eye(orth_coeff.shape[0]), verbose=0)
+    nelec = np.zeros(mol.natm, dtype=float)
+    for i, label in enumerate(mol.ao_labels(fmt=None)):
+        nelec[label[0]] += float(pop[i])
+    return nelec
+
+
+def nao_Qa_Sa_from_mf(mol: Mole, mf: SCF) -> tuple[np.ndarray, np.ndarray]:
+    """Per-atom charge-like ``Qa`` and spin-proxy ``Sa`` from NAO populations.
+
+    Convention (aligned with OMol ``nbo_charges`` / ``nbo_spins`` checks):
+
+    - ``Qa``: formal atomic charge, ``Z_A - (n_alpha + n_beta)`` in the NAO basis.
+    - ``Sa``: ``n_alpha - n_beta`` per atom (closed-shell singlet → zeros).
+    - ``sum(Qa) ≈ mol.charge``, ``sum(Sa) ≈ mol.spin`` (unpaired electrons).
+    """
+    s = _overlap(mf)
+    nuclear = mol.atom_charges()
+
+    if isinstance(mf, scf.uhf.UHF):
+        dm_alpha, dm_beta = mf.make_rdm1()
+        n_alpha = _nao_ao_populations_per_atom(mol, mf, dm_alpha, s)
+        n_beta = _nao_ao_populations_per_atom(mol, mf, dm_beta, s)
+        qa = nuclear - (n_alpha + n_beta)
+        sa = n_alpha - n_beta
+        return qa, sa
+
+    if isinstance(mf, scf.rohf.ROHF):
+        dm = mf.make_rdm1()
+        if isinstance(dm, (list, tuple)):
+            dm = dm[0] + dm[1]
+    else:
+        dm = mf.make_rdm1()
+
+    n_total = _nao_ao_populations_per_atom(mol, mf, dm, s)
+    qa = nuclear - n_total
+    return qa, np.zeros(mol.natm, dtype=float)

--- a/enerzyme/qm/xtb_population/__init__.py
+++ b/enerzyme/qm/xtb_population/__init__.py
@@ -1,0 +1,13 @@
+"""GFN2-xTB + xtbml per-atom charge/spin populations (Mulliken-type) for Enerzyme preprocessing."""
+
+from .deps import check_xtbml_dependencies
+
+__all__ = ["check_xtbml_dependencies", "atomic_Q_and_S_from_xtbml"]
+
+
+def atomic_Q_and_S_from_xtbml(*args, **kwargs):
+    """Run xTB + xtbml; loads tblite on first use after :func:`check_xtbml_dependencies`."""
+    check_xtbml_dependencies()
+    from .atomic_populations import atomic_Q_and_S_from_xtbml as _fn
+
+    return _fn(*args, **kwargs)

--- a/enerzyme/qm/xtb_population/atomic_populations.py
+++ b/enerzyme/qm/xtb_population/atomic_populations.py
@@ -1,0 +1,129 @@
+"""ASE + tblite xtbml: per-atom Mulliken-type charge Q_a and spin proxy S_a from ``atoms.info``.
+
+``atoms.info`` uses:
+
+- ``charge``: total molecular charge (e).
+- ``spin``: spin multiplicity M (2S+1), integer ≥ 1 (default 1 if missing).
+
+xTB uses ``GFN2-xTB``. For M ≠ 1, ``spin-polarization`` is added so xtbml exposes
+``q_A_alpha`` / ``q_A_beta``; for M = 1, closed-shell ``q_A`` only.
+
+When ``max_scf_iter`` is small (e.g. 1), SCC may not converge. tblite then raises
+``TBLiteRuntimeError``, but the last-cycle ``Result`` (including xtbml
+``post-processing-dict``) is still read—this is intentional for one-shot SCC workflows.
+
+Returns:
+
+- **Q_a**: ``q_A_alpha + q_A_beta`` when split exists, else merged ``q_A``.
+- **S_a**: ``q_A_alpha - q_A_beta`` when split exists, else zeros (singlet / merged channel).
+
+Requires: ``ase``, ``tblite`` with xtbml (see ``xtbml_charges.py``). Use
+:func:`enerzyme.qm.xtb_population.deps.check_xtbml_dependencies` before calling in contexts
+where optional deps may be missing.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, cast
+
+import numpy as np
+from tblite.exceptions import TBLiteRuntimeError
+from tblite.interface import Calculator, Result
+
+from .xtbml_charges import register_xtbml
+
+if TYPE_CHECKING:
+    from ase import Atoms
+
+
+def _atoms_to_tblite_inputs(atoms: Atoms) -> tuple[np.ndarray, np.ndarray]:
+    from ase.units import Bohr
+
+    z = np.asarray(atoms.get_atomic_numbers(), dtype=int)
+    pos = np.asarray(atoms.get_positions(wrap=False), dtype=float) / Bohr
+    return z, pos
+
+
+def _read_charge_spin(atoms: Atoms) -> tuple[float, int]:
+    info = atoms.info
+    charge = float(info.get("charge", 0.0))
+    mult = int(info.get("spin", 1))
+    if mult < 1:
+        raise ValueError("atoms.info['spin'] (multiplicity) must be >= 1")
+    return charge, mult
+
+
+def _uhf_from_multiplicity(mult: int) -> int:
+    """tblite ``uhf`` = number of unpaired electrons for high-spin open shell (M−1)."""
+    return max(0, mult - 1)
+
+
+def _post_processing_dict(res: Result) -> Mapping[str, Any]:
+    raw = res.get("post-processing-dict")
+    if not isinstance(raw, Mapping):
+        raise TypeError("Result has no post-processing-dict mapping")
+    return cast(Mapping[str, Any], raw)
+
+
+def atomic_Q_and_S_from_xtbml(
+    atoms: Atoms,
+    max_scf_iter: int = 1,
+    *,
+    spin_polarization_gamma: float = 1.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run GFN2-xTB + xtbml and return per-atom Q_a and S_a (see module docstring)."""
+    numbers, positions = _atoms_to_tblite_inputs(atoms)
+    charge, multiplicity = _read_charge_spin(atoms)
+    uhf = _uhf_from_multiplicity(multiplicity)
+
+    calc = Calculator("GFN2-xTB", numbers, positions, charge=charge, uhf=uhf)
+    calc.set("max-iter", int(max_scf_iter))
+    calc.set("verbosity", 0)
+
+    # Empirical spin polarization: forces two-spin xtbml density when M ≠ 1
+    if multiplicity != 1:
+        calc.add("spin-polarization", float(spin_polarization_gamma))
+
+    register_xtbml(calc)
+    res = Result()
+    try:
+        calc.singlepoint(res)
+    except TBLiteRuntimeError:
+        # Last SCC cycle is still stored on ``res`` (e.g. SCF not converged in 1 cycle).
+        pass
+
+    n = int(res.get("natoms"))
+    pp = _post_processing_dict(res)
+
+    q_alpha = (
+        np.asarray(pp["q_A_alpha"], dtype=float).reshape(-1)
+        if "q_A_alpha" in pp
+        else None
+    )
+    q_beta = (
+        np.asarray(pp["q_A_beta"], dtype=float).reshape(-1)
+        if "q_A_beta" in pp
+        else None
+    )
+    q_merged = (
+        np.asarray(pp["q_A"], dtype=float).reshape(-1) if "q_A" in pp else None
+    )
+
+    if q_alpha is not None and q_beta is not None:
+        if q_alpha.size != n or q_beta.size != n:
+            raise ValueError("q_A_alpha / q_A_beta length mismatch with natoms")
+        qa = q_alpha + q_beta
+        sa = q_alpha - q_beta
+        return qa, sa
+
+    if multiplicity != 1:
+        raise RuntimeError(
+            "Expected xtbml spin-split keys q_A_alpha and q_A_beta for multiplicity != 1; "
+            f"got keys containing q_A: {[k for k in pp if 'q_A' in k]!r}"
+        )
+
+    if q_merged is None or q_merged.size != n:
+        raise RuntimeError(
+            "Singlet run expected merged q_A in post-processing-dict; "
+            f"q_A-related keys: {[k for k in pp if 'q_A' in k]!r}"
+        )
+    return q_merged, np.zeros(n, dtype=float)

--- a/enerzyme/qm/xtb_population/deps.py
+++ b/enerzyme/qm/xtb_population/deps.py
@@ -1,0 +1,19 @@
+"""Runtime dependency checks for GFN2-xTB + xtbml atomic population helpers."""
+
+
+def check_xtbml_dependencies() -> None:
+    """Verify packages needed for ``xtb_qs_prior`` preprocessing. Raises ``ImportError`` with install hints."""
+    try:
+        import ase  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "xtb_qs_prior requires ASE. Install with: pip install ase"
+        ) from exc
+    try:
+        from tblite.exceptions import TBLiteRuntimeError  # noqa: F401
+        from tblite.interface import Calculator, Result  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "xtb_qs_prior requires tblite (GFN-xTB + xtbml post-processing). "
+            "Install tblite >= 0.5 with xtbml-enabled libtblite (conda/pip per your platform)."
+        ) from exc

--- a/enerzyme/qm/xtb_population/xtbml.toml
+++ b/enerzyme/qm/xtb_population/xtbml.toml
@@ -1,0 +1,11 @@
+# Minimal xTB-ML (xtbml) post-processing: density / Mulliken-based descriptors including q_A.
+# Schema matches upstream: https://github.com/tblite/tblite/blob/main/test/cli/test/xtbml.toml
+# Used as fallback when ``Calculator.add("xtbml")`` is unavailable but the library supports TOML.
+
+[post-processing.xtbml]
+geometry = false
+density = true
+orbital = false
+energy = false
+convolution = false
+tensorial-output = false

--- a/enerzyme/qm/xtb_population/xtbml_charges.py
+++ b/enerzyme/qm/xtb_population/xtbml_charges.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""xtbml density-class atomic charges: q_A (RHF) and q_A_alpha / q_A_beta vs Result.charges.
+
+**Alpha/beta channel charges** (``q_A_alpha``, ``q_A_beta``): on a closed-shell
+geometry, ``Calculator.add("spin-polarization", γ)`` makes the xtbml density block
+use ``wfn%nspin > 1``, which emits density-class keys with ``_alpha``/``_beta`` suffixes.
+
+For pure UHF (e.g. OH), if xtbml still represents a single density channel, only the
+merged ``q_A`` may be present; orbital-energy keys can still appear as ``*_alpha``.
+See the ``spin_label`` branch in Fortran ``density.f90``.
+
+Requires tblite with xtbml post-processing: ``Calculator.add("xtbml")`` (tblite >= 0.5.0 and
+libtblite built with xtbml). If ``add("xtbml")`` is missing, this module falls back to
+``xtbml.toml`` next to this file via the C API. tblite 0.4.0 has neither and cannot provide q_A.
+
+Bundled with Enerzyme under ``enerzyme.qm.xtb_population``. Run ``main()`` from this module
+in an environment with tblite >= 0.5 for a self-test.
+"""
+from __future__ import annotations
+
+import importlib.metadata as im
+import sys
+from pathlib import Path
+from typing import Any, Literal, Mapping, TypedDict, cast
+
+ChargeMode = Literal["rhf_merged", "spin_split", "uhf"]
+
+import numpy as np
+
+from tblite.exceptions import TBLiteValueError
+from tblite.interface import Calculator, Result
+from tblite import library as _tblite_library
+
+
+def _this_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def register_xtbml(calc: Calculator) -> str:
+    """Register xtbml post-processing. Returns a short label describing how it was done."""
+    try:
+        calc.add("xtbml")
+        return "add('xtbml')"
+    except TBLiteValueError:
+        toml = _this_dir() / "xtbml.toml"
+        if not toml.is_file():
+            raise
+        # Same path the broken early 0.4.x toml branch intended: pass path string to the library
+        _tblite_library.post_processing_push_back(calc._ctx, calc._calc, str(toml))
+        return f"post_processing_push_back({toml.name!r})"
+
+
+def _as1d(
+    d: Mapping[str, Any], key: str, *, n_expected: int | None = None
+) -> np.ndarray:
+    v = d[key]
+    a = np.asarray(v, dtype=float).reshape(-1)
+    if n_expected is not None and a.size != n_expected:
+        raise ValueError(f"{key}: expected size {n_expected}, got {a.size}")
+    return a
+
+
+def extract_xtbml_charges(
+    res: Result,
+    *,
+    n_atoms: int,
+    mode: ChargeMode,
+) -> dict[str, np.ndarray | None]:
+    """Read xtbml partial charges from ``post-processing-dict`` (keys depend on wf / tblite).
+
+    - **rhf_merged**: closed shell w/o ``spin-polarization`` → expect ``q_A``.
+    - **spin_split**: e.g. ``Calculator.add('spin-polarization', γ)`` with closed shell → expect
+      ``q_A_alpha`` and ``q_A_beta`` (no merged ``q_A`` in typical builds).
+    - **uhf**: open shell → either spin-split or merged ``q_A`` (see module docstring).
+    """
+    # Result.get for post-processing may return a dict-like or plain dict
+    raw = res.get("post-processing-dict")
+    if not isinstance(raw, Mapping):
+        raise TypeError("post-processing-dict is missing or not a mapping")
+    pp: Mapping[str, Any] = cast(Mapping[str, Any], raw)
+
+    out: dict[str, np.ndarray | None] = {
+        "q_A": None,
+        "q_A_alpha": None,
+        "q_A_beta": None,
+    }
+    if "q_A" in pp:
+        out["q_A"] = _as1d(pp, "q_A", n_expected=n_atoms)
+    if "q_A_alpha" in pp:
+        out["q_A_alpha"] = _as1d(pp, "q_A_alpha", n_expected=n_atoms)
+    if "q_A_beta" in pp:
+        out["q_A_beta"] = _as1d(pp, "q_A_beta", n_expected=n_atoms)
+
+    has_split = out["q_A_alpha"] is not None and out["q_A_beta"] is not None
+    has_merged = out["q_A"] is not None
+
+    if mode == "rhf_merged":
+        if out["q_A"] is None:
+            raise KeyError(
+                "rhf_merged: expected key 'q_A'; "
+                f"sample keys: {sorted(pp.keys())[:40]}..."
+            )
+    elif mode == "spin_split":
+        if not has_split:
+            raise KeyError(
+                "spin_split: expected 'q_A_alpha' and 'q_A_beta' (use spin-polarization); "
+                f"sample keys: {sorted(pp.keys())[:40]}..."
+            )
+    else:  # uhf
+        if not has_split and not has_merged:
+            raise KeyError(
+                "uhf: expected spin-split (q_A_alpha, q_A_beta) or merged q_A; "
+                f"sample keys: {sorted(pp.keys())[:50]}..."
+            )
+    return out
+
+
+class CaseReport(TypedDict):
+    label: str
+    register: str
+    charges: list[float]
+    q_A: list[float] | None
+    q_A_alpha: list[float] | None
+    q_A_beta: list[float] | None
+    max_abs_diff_qA_vs_charges: float | None
+    max_abs_diff_sumab_vs_charges: float | None
+    n_post_processing_keys: int
+    post_processing_keys_sample: list[str]
+
+
+def _run_case(
+    label: str,
+    numbers: np.ndarray,
+    positions: np.ndarray,
+    *,
+    charge: float | None = None,
+    uhf: int | None = None,
+    mode: ChargeMode,
+    spin_polarization: float | None = None,
+) -> CaseReport:
+    calc = Calculator("GFN2-xTB", numbers, positions, charge=charge, uhf=uhf)
+    if spin_polarization is not None:
+        calc.add("spin-polarization", float(spin_polarization))
+    how = register_xtbml(calc)
+    res = calc.singlepoint()
+    n = int(res.get("natoms"))
+    ch = np.asarray(res.get("charges"), dtype=float).reshape(-1)
+    xq = extract_xtbml_charges(res, n_atoms=n, mode=mode)
+    raw = res.get("post-processing-dict")
+    pp = cast(Mapping[str, Any], raw) if isinstance(raw, Mapping) else {}
+    keys = sorted(pp.keys())
+    n_keys = len(keys)
+
+    has_ab = xq["q_A_alpha"] is not None and xq["q_A_beta"] is not None
+
+    # Primary comparison: spin-split totals vs Mulliken charges, or merged q_A vs charges
+    d_qa: float | None = None
+    d_sum: float | None = None
+    if has_ab:
+        qa_part = cast(np.ndarray, xq["q_A_alpha"])
+        qb_part = cast(np.ndarray, xq["q_A_beta"])
+        q_sum = qa_part + qb_part
+        d_sum = float(np.max(np.abs(q_sum - ch)))
+        if xq["q_A"] is not None:
+            d_qa = float(np.max(np.abs(xq["q_A"] - ch)))
+    elif xq["q_A"] is not None:
+        d_qa = float(np.max(np.abs(xq["q_A"] - ch)))
+
+    return {
+        "label": label,
+        "register": how,
+        "charges": ch.tolist(),
+        "q_A": xq["q_A"].tolist() if xq["q_A"] is not None else None,
+        "q_A_alpha": xq["q_A_alpha"].tolist() if xq["q_A_alpha"] is not None else None,
+        "q_A_beta": xq["q_A_beta"].tolist() if xq["q_A_beta"] is not None else None,
+        "max_abs_diff_qA_vs_charges": d_qa,
+        "max_abs_diff_sumab_vs_charges": d_sum,
+        "n_post_processing_keys": n_keys,
+        "post_processing_keys_sample": keys[:30],
+    }
+
+
+def _print_report(r: CaseReport) -> None:
+    print(f"=== {r['label']} ===")
+    print(f"  xtbml registration: {r['register']}")
+    print(f"  Result.get('charges') (Mulliken, e): {r['charges']!r}")
+    if r["q_A"] is not None:
+        print(f"  xtbml q_A: {r['q_A']!r}")
+    if r["q_A_alpha"] is not None:
+        print(f"  xtbml q_A_alpha: {r['q_A_alpha']!r}")
+    if r["q_A_beta"] is not None:
+        print(f"  xtbml q_A_beta: {r['q_A_beta']!r}")
+    if r["max_abs_diff_qA_vs_charges"] is not None:
+        print(
+            "  max |q_A - charges| (if q_A present vs charges): "
+            f"{r['max_abs_diff_qA_vs_charges']:.2e}"
+        )
+    if r["max_abs_diff_sumab_vs_charges"] is not None:
+        print(
+            "  max |q_A_alpha + q_A_beta - charges|: "
+            f"{r['max_abs_diff_sumab_vs_charges']:.2e}"
+        )
+    print(
+        f"  post-processing-dict: {r['n_post_processing_keys']} keys "
+        f"(first <=30: {r['post_processing_keys_sample']!r})"
+    )
+    print()
+
+
+def _tblite_version_tuple() -> tuple[int, int, int]:
+    v = im.version("tblite")
+    parts = v.split(".")
+    ns: list[int] = []
+    for p in parts[:3]:
+        try:
+            ns.append(int("".join(ch for ch in p if ch.isdigit()) or "0"))
+        except ValueError:
+            ns.append(0)
+    while len(ns) < 3:
+        ns.append(0)
+    return (ns[0], ns[1], ns[2])
+
+
+def main() -> int:
+    try:
+        v = im.version("tblite")
+    except Exception:
+        v = "unknown"
+    print("tblite (metadata):", v, flush=True)
+    print(flush=True)
+
+    if v != "unknown" and _tblite_version_tuple() < (0, 5, 0):
+        print(
+            "This tblite is older than 0.5.0: xtbml is not available via "
+            "Calculator.add('xtbml') and the bundled libtblite has no xtbml "
+            "post-processing, so q_A will not appear. Upgrade tblite and "
+            "libtblite, then re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # H2O, closed shell (Bohr), same as env_check / scf_steps_probe
+    h2o_numbers = np.array([8, 1, 1], dtype=int)
+    h2o_pos = np.array(
+        [
+            [0.0, 0.0, 0.119262],
+            [0.0, 0.763239, -0.477257],
+            [0.0, -0.763239, -0.477257],
+        ],
+        dtype=float,
+    )
+    # OH doublet: 9 electrons, one unpaired; linear along z, ~1.8 Bohr O–H
+    oh_numbers = np.array([8, 1], dtype=int)
+    oh_pos = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.8324],
+        ],
+        dtype=float,
+    )
+
+    try:
+        r_rhf = _run_case(
+            "H2O closed-shell (RHF) — q_A",
+            h2o_numbers,
+            h2o_pos,
+            mode="rhf_merged",
+        )
+        # Two-spin density (wfn%nspin>1 in xtbml): closed shell + empirical spin-polarization
+        r_sp = _run_case(
+            "H2O + spin-polarization (γ=1) — q_A_alpha, q_A_beta",
+            h2o_numbers,
+            h2o_pos,
+            mode="spin_split",
+            spin_polarization=1.0,
+        )
+        r_uhf = _run_case(
+            "OH doublet (UHF) — q_A splits or merged q_A",
+            oh_numbers,
+            oh_pos,
+            charge=0.0,
+            uhf=1,
+            mode="uhf",
+        )
+    except TBLiteValueError as exc:
+        print("Could not register xtbml post-processing.", file=sys.stderr)
+        print(
+            "Install tblite >= 0.5.0 (and a matching libtblite with xtbml), or see xtbml.toml.",
+            file=sys.stderr,
+        )
+        print(f"Exception: {exc!r}", file=sys.stderr)
+        return 1
+    except (KeyError, TypeError) as exc:
+        print(
+            "Single-point finished but xtbml charges are missing from post-processing-dict.",
+            file=sys.stderr,
+        )
+        print(
+            "Either xtbml is missing or density keys failed to populate.",
+            file=sys.stderr,
+        )
+        print(f"Exception: {exc!r}", file=sys.stderr)
+        return 1
+
+    _print_report(r_rhf)
+    _print_report(r_sp)
+    _print_report(r_uhf)
+
+    # Soft validation against Mulliken `charges` (same xTB density; definitions still aligned)
+    atol = 5e-4
+
+    def _sum_ab_tolerance_ok(case: CaseReport) -> tuple[bool, str]:
+        if case["max_abs_diff_sumab_vs_charges"] is None:
+            return (False, "no sum α+β comparand")
+        d = case["max_abs_diff_sumab_vs_charges"]
+        return (d <= atol, "max |q_A_alpha+q_A_beta-charges|")
+
+    def _uhf_tolerance_ok(case: CaseReport) -> tuple[bool, str]:
+        if case["max_abs_diff_sumab_vs_charges"] is not None:
+            d = case["max_abs_diff_sumab_vs_charges"]
+            return (d <= atol, "max |q_A_alpha+q_A_beta-charges|")
+        if case["max_abs_diff_qA_vs_charges"] is not None:
+            d = case["max_abs_diff_qA_vs_charges"]
+            return (
+                d <= atol,
+                "max |q_A-charges| (merged density block)",
+            )
+        return (False, "no comparand")
+
+    if r_rhf["max_abs_diff_qA_vs_charges"] is not None:
+        if r_rhf["max_abs_diff_qA_vs_charges"] > atol:
+            print(
+                f"WARNING: RHF |q_A - charges|_max = {r_rhf['max_abs_diff_qA_vs_charges']:.2e} "
+                f"exceeds {atol!r} (tune tolerance if your tblite build differs).",
+                file=sys.stderr,
+            )
+            return 1
+    ok_sp, label_sp = _sum_ab_tolerance_ok(r_sp)
+    if not ok_sp:
+        print(
+            f"WARNING: spin-polarization test {label_sp} exceeds {atol!r} "
+            f"(sumab={r_sp['max_abs_diff_sumab_vs_charges']!r}).",
+            file=sys.stderr,
+        )
+        return 1
+    ok_u, label_u = _uhf_tolerance_ok(r_uhf)
+    if not ok_u:
+        print(
+            f"WARNING: UHF {label_u} exceeds {atol!r} "
+            f"(sumab={r_uhf['max_abs_diff_sumab_vs_charges']!r}, "
+            f"qa={r_uhf['max_abs_diff_qA_vs_charges']!r}).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/enerzyme/tasks/batch.py
+++ b/enerzyme/tasks/batch.py
@@ -332,6 +332,19 @@ def _decorate_batch_output(output: Dict[str, Any], features: Dict[str, Any], tar
         y_truth["data_key"] = targets["data_key"]
     y_truth["Za"] = y_pred["Za"]
 
+    # Delta-learning inverse: priors must sit next to residual Qa / Sa on the metric dict
+    for _prior_key in ("Q_init_a", "S_init_a"):
+        if _prior_key in features and is_atomic(_prior_key):
+            split_prior = list(
+                map(
+                    lambda x: x.detach().cpu().numpy(),
+                    torch.split(features[_prior_key], features["N"]),
+                )
+            )
+            y_pred[_prior_key] = split_prior
+            if targets is not None:
+                y_truth[_prior_key] = split_prior
+
     # Graph-level Q / S targets with atomic-only model output (e.g. ODE flow returns Qa, Sa only).
     if targets is not None:
         if (

--- a/enerzyme/tasks/trainer.py
+++ b/enerzyme/tasks/trainer.py
@@ -475,7 +475,13 @@ class Trainer:
                     pin_memory=True,
                     num_workers=max(1, self.num_workers)
                 )
-                self.lightning_trainer.test(model, test_dataloader)
+                self.lightning_trainer.test(lightning_model, test_dataloader)
+                return lightning_model.test_result or {
+                    "y_pred": None,
+                    "y_truth": None,
+                    "metric_score": None,
+                }
+            return {"y_pred": None, "y_truth": None, "metric_score": None}
         else:
             model = model.to(device=self.device, dtype=self.dtype)
             if self.use_ema:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     extras_require={
         # ODE integration for architecture uma_flow_qs / Generator predict
         "flow": ["torchdiffeq"],
+        # Optional Q/S prior backends for Datahub transforms (runtime-checked in deps.py)
+        "xtb": ["tblite>=0.5"],
+        "pyscf_nao": ["pyscf"],
     },
     entry_points={'console_scripts': ['enerzyme=enerzyme.cli:main']},
     packages=find_packages(include=["enerzyme", "enerzyme.*"]),
@@ -22,6 +25,7 @@ setup(
         "models/so3/cgmatrix.npz",
         "models/so3/data/lebedev_grids.npz",
         "models/efa/NOTICE",
+        "qm/xtb_population/xtbml.toml",
     ]},
     auth='Benzoin96485',
     author_email='luowl7@mit.edu',

--- a/test/test_aselmdb.py
+++ b/test/test_aselmdb.py
@@ -92,6 +92,78 @@ def test_aselmdb_dataset_loads_dipole_as_m2(tmp_path):
     np.testing.assert_allclose(ds["M2"][0], dipole)
 
 
+def _write_toy_aselmdb_initial_qs(
+    db_path,
+    *,
+    initial_charges,
+    initial_magmoms,
+    charge,
+    spin,
+    index=0,
+):
+    """ASE DB with populations only on ``initial_*`` (no calculator)."""
+    atoms = Atoms("H2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]])
+    atoms.set_initial_charges(np.asarray(initial_charges, dtype=float))
+    atoms.set_initial_magnetic_moments(np.asarray(initial_magmoms, dtype=float))
+    with connect(str(db_path)) as db:
+        db.write(atoms, data={"charge": charge, "spin": spin, "index": index}, index=index)
+
+
+def test_aselmdb_dataset_loads_qa_sa_from_initial_arrays(tmp_path):
+    """DBs without a calculator still expose Qa/Sa via ASE initial_* arrays."""
+    db_path = tmp_path / "initial_qs.aselmdb"
+    qa = np.array([0.4, -0.4])
+    sa = np.array([0.7, 0.3])
+    charge, spin = 0, 2  # S = spin - 1 = 1
+    _write_toy_aselmdb_initial_qs(
+        db_path,
+        initial_charges=qa,
+        initial_magmoms=sa,
+        charge=charge,
+        spin=spin,
+    )
+
+    ds = ASELMDBDataset(str(db_path), new_energy_unit="Ha")
+    assert "Qa" in ds and "Sa" in ds
+    assert "Q" in ds and "S" in ds
+    assert "Qa" in ds.unique_properties_from_calculator
+    assert "Sa" in ds.unique_properties_from_calculator
+    np.testing.assert_allclose(ds["Qa"][0], qa)
+    np.testing.assert_allclose(ds["Sa"][0], sa)
+    assert ds["Q"][0] == charge
+    assert ds["S"][0] == spin - 1
+    assert float(np.sum(ds["Qa"][0])) == pytest.approx(ds["Q"][0], abs=1e-6)
+    assert float(np.sum(ds["Sa"][0])) == pytest.approx(ds["S"][0], abs=1e-6)
+
+
+def test_aselmdb_calculator_qs_wins_over_initial_arrays(tmp_path):
+    """Calculator charges/magmoms take priority over ASE initial_* arrays."""
+    db_path = tmp_path / "calc_over_initial.aselmdb"
+    initial_qa = np.array([0.9, -0.9])
+    initial_sa = np.array([2.0, 0.0])
+    calc_qa = np.array([0.25, -0.25])
+    calc_sa = np.array([0.6, 0.4])
+    atoms = Atoms("H2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]])
+    atoms.set_initial_charges(initial_qa)
+    atoms.set_initial_magnetic_moments(initial_sa)
+    atoms.calc = SinglePointCalculator(
+        atoms,
+        energy=-1.0,
+        forces=np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0]]),
+        charges=calc_qa,
+        magmoms=calc_sa,
+    )
+    with connect(str(db_path)) as db:
+        db.write(atoms, data={"charge": 0, "spin": 2, "index": 0}, index=0)
+
+    ds = ASELMDBDataset(str(db_path), new_energy_unit="Ha")
+    assert "Qa" in ds and "Sa" in ds
+    np.testing.assert_allclose(ds["Qa"][0], calc_qa)
+    np.testing.assert_allclose(ds["Sa"][0], calc_sa)
+    assert not np.allclose(ds["Qa"][0], initial_qa)
+    assert not np.allclose(ds["Sa"][0], initial_sa)
+
+
 def test_aselmdb_declared_m2_when_first_row_lacks_dipole(tmp_path):
     """Declared / schema registration must not depend on the first row alone."""
     from enerzyme.data.datahub import ASELMDB_METADATA_PROPERTIES_KEY

--- a/test/test_pyscf_nao_population_transform.py
+++ b/test/test_pyscf_nao_population_transform.py
@@ -1,0 +1,238 @@
+"""Tests for PySCF NAO Q/S prior and qs_delta (no GPU/PySCF required)."""
+
+import os
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from enerzyme.data.transform import (
+    PySCFNAOQSPriorTransform,
+    QSDeltaTransform,
+    Transform,
+    UniformSplitQSTransform,
+)
+
+
+def test_pyscf_prior_requires_xc_basis_without_mock():
+    with pytest.raises(ValueError, match="xc.*basis"):
+        PySCFNAOQSPriorTransform()
+
+
+def test_pyscf_prior_transform_uses_mock_fn():
+    calls = []
+
+    def fake_atomic(atoms, max_scf_iter, **_kw):
+        calls.append((len(atoms), int(max_scf_iter)))
+        n = len(atoms)
+        return np.arange(n, dtype=np.float64) * 0.01, np.zeros(n, dtype=np.float64)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[1, 1, 0]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((1, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            PySCFNAOQSPriorTransform(
+                atomic_qs_fn=fake_atomic,
+                xc="b3lyp",
+                basis="sto-3g",
+                max_scf_iter=2,
+            ).transform(g)
+            assert len(calls) == 1 and calls[0][0] == 2 and calls[0][1] == 2
+            qia = np.asarray(g["Q_init_a"][:])
+            assert qia.shape == (1, 3)
+            assert np.isclose(qia[0, :2].sum(), 0.0)
+
+
+def test_transform_yaml_pyscf_and_delta_hooks():
+    tr = Transform(
+        {
+            "pyscf_nao_qs_prior": {
+                "enabled": True,
+                "xc": "wb97m-v",
+                "basis": "def2-svp",
+                "atomic_qs_fn": lambda *a, **k: (np.zeros(1), np.zeros(1)),
+            },
+            "qs_delta": True,
+        }
+    )
+    assert len(tr.pyscf_nao_qs_priors) == 1 and len(tr.qs_deltas) == 1
+
+
+def test_transform_rejects_uniform_and_pyscf_together():
+    with pytest.raises(ValueError, match="only one of uniform_qs_init"):
+        Transform(
+            {
+                "uniform_qs_init": True,
+                "pyscf_nao_qs_prior": {
+                    "enabled": True,
+                    "xc": "b3lyp",
+                    "basis": "sto-3g",
+                    "atomic_qs_fn": lambda *a, **k: (np.zeros(1), np.zeros(1)),
+                },
+            }
+        )
+
+
+def test_qs_delta_zero_sum_with_pyscf_prior_mock():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[6, 6, 0]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((1, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("Qa", data=np.array([[0.1, -0.1, 0.0]], dtype=np.float64))
+            g.create_dataset("Sa", data=np.array([[0.05, -0.05, 0.0]], dtype=np.float64))
+
+        def uniform_prior(atoms, max_scf_iter, **_kw):
+            n = len(atoms)
+            inv = 1.0 / n
+            return np.full(n, 0.0), np.zeros(n)
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            PySCFNAOQSPriorTransform(
+                atomic_qs_fn=uniform_prior,
+                xc="b3lyp",
+                basis="sto-3g",
+            ).transform(g)
+            QSDeltaTransform().transform(g)
+            dq = np.asarray(g["Qa"][0, :2])
+            ds = np.asarray(g["Sa"][0, :2])
+            assert np.isclose(dq.sum(), 0.0, atol=1e-9)
+            assert np.isclose(ds.sum(), 0.0, atol=1e-9)
+            assert "Q_delta_a" not in g
+
+
+def test_transform_forward_order_pyscf_before_delta():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[6, 6, 0]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((1, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("Qa", data=np.array([[0.1, -0.1, 0.0]], dtype=np.float64))
+            g.create_dataset("Sa", data=np.array([[0.05, -0.05, 0.0]], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            Transform(
+                {
+                    "qs_delta": True,
+                    "pyscf_nao_qs_prior": {
+                        "enabled": True,
+                        "xc": "b3lyp",
+                        "basis": "sto-3g",
+                        "atomic_qs_fn": lambda atoms, max_scf_iter, **kw: (
+                            np.zeros(len(atoms)),
+                            np.zeros(len(atoms)),
+                        ),
+                    },
+                }
+            ).transform(g)
+            assert "Q_init_a" in g and np.isclose(np.asarray(g["Qa"][0, :2]).sum(), 0.0, atol=1e-9)
+
+
+def test_pyscf_prior_uses_ra_frame_count_when_n_compressed():
+    calls = []
+
+    def fake_atomic(atoms, max_scf_iter, **_kw):
+        calls.append((len(atoms), int(max_scf_iter)))
+        n = len(atoms)
+        return np.zeros(n, dtype=np.float64), np.zeros(n, dtype=np.float64)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([3], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((4, 3, 3), dtype=np.float64))
+            g.create_dataset("Za", data=np.array([[6, 6, 6]], dtype=np.int32))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            PySCFNAOQSPriorTransform(
+                atomic_qs_fn=fake_atomic,
+                xc="b3lyp",
+                basis="sto-3g",
+            ).transform(g)
+            qia = np.asarray(g["Q_init_a"][:])
+            assert qia.shape == (4, 3)
+            assert len(calls) == 4
+
+
+def test_datahub_populate_pyscf_from_preprocessings(tmp_path):
+    import pickle
+    from pathlib import Path
+
+    from enerzyme.data.datahub import SingleDataHub
+
+    frames = [
+        {
+            "atom_type": ["C", "O"],
+            "coord": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0]],
+            "total_chrg": 0,
+            "total_spin": 0,
+        }
+    ]
+    pkl = Path(tmp_path) / "qs.pkl"
+    with open(pkl, "wb") as f:
+        pickle.dump(frames, f)
+
+    def fake_atomic(atoms, max_scf_iter=1, **kw):
+        n = len(atoms)
+        return np.zeros(n, dtype=np.float64), np.zeros(n, dtype=np.float64)
+
+    hub = SingleDataHub(
+        dump_dir=str(Path(tmp_path) / "out"),
+        data_path=str(pkl),
+        data_format="pickle",
+        preload=True,
+        neighbor_list="",
+        features={"Ra": "coord", "Za": "atom_type", "Q": "total_chrg", "S": "total_spin", "N": None},
+        targets={},
+        preprocessings={
+            "pyscf_nao_qs_prior": {
+                "enabled": True,
+                "xc": "b3lyp",
+                "basis": "sto-3g",
+                "atomic_qs_fn": fake_atomic,
+            }
+        },
+        global_transforms=None,
+    )
+    assert hub._populate_pyscf_nao_qs_prior
+    assert "Q_init_a" in hub.feature_types
+    assert "Q_init_a" in hub.features
+
+
+def test_check_pyscf_nao_dependencies_import_error(monkeypatch):
+    import builtins
+    import enerzyme.qm.pyscf_nao_population.deps as deps
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyscf" or name.startswith("pyscf."):
+            raise ImportError("no pyscf")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="requires PySCF"):
+        deps.check_pyscf_nao_dependencies(use_gpu=False)

--- a/test/test_xtb_population_transform.py
+++ b/test/test_xtb_population_transform.py
@@ -1,0 +1,249 @@
+"""Tests for xtb_population-backed Q/S prior and atomic delta transforms (no tblite required)."""
+
+import os
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from enerzyme.data.transform import (
+    QSDeltaTransform,
+    Transform,
+    UniformSplitQSTransform,
+    XTBQSPriorTransform,
+)
+
+
+def test_qs_delta_zero_sum_with_uniform_prior():
+    """After uniform init, transformed Qa / Sa residual labels sum to ~0 per frame."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2, 3], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[6, 6, 0], [7, 7, 7]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((2, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0, -1.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0, 1.0], dtype=np.float64))
+            # Per-frame Qa/Sa must match Q/S so delta w.r.t. uniform prior is zero-sum
+            g.create_dataset(
+                "Qa",
+                data=np.array([[0.1, -0.1, 0.0], [-1.0 / 3.0, -1.0 / 3.0, -1.0 / 3.0]], dtype=np.float64),
+            )
+            g.create_dataset(
+                "Sa",
+                data=np.array([[0.05, -0.05, 0.0], [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]], dtype=np.float64),
+            )
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            UniformSplitQSTransform().transform(g)
+            QSDeltaTransform().transform(g)
+            dq = np.asarray(g["Qa"][:])
+            ds = np.asarray(g["Sa"][:])
+            for i, n in enumerate([2, 3]):
+                assert np.isclose(dq[i, :n].sum(), 0.0, atol=1e-9)
+                assert np.isclose(ds[i, :n].sum(), 0.0, atol=1e-9)
+            assert "Q_delta_a" not in g and "S_delta_a" not in g
+
+
+def test_xtb_prior_transform_uses_mock_fn():
+    """XTBQSPriorTransform with injected callable (no tblite)."""
+    calls = []
+
+    def fake_atomic(atoms, max_scf_iter=1, **kw):
+        calls.append((len(atoms), int(max_scf_iter)))
+        n = len(atoms)
+        return np.arange(n, dtype=np.float64) * 0.01, np.zeros(n, dtype=np.float64)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[1, 1, 0]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((1, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            XTBQSPriorTransform(atomic_qs_fn=fake_atomic, max_scf_iter=3).transform(g)
+            assert len(calls) == 1 and calls[0] == (2, 3)
+            qia = np.asarray(g["Q_init_a"][:])
+            assert qia.shape == (1, 3)
+            assert np.isclose(qia[0, :2].sum(), 0.0)
+
+
+def test_transform_yaml_xtb_and_delta_hooks():
+    tr = Transform(
+        {
+            "xtb_qs_prior": {
+                "enabled": True,
+                "atomic_qs_fn": lambda *a, **k: (np.zeros(1), np.zeros(1)),
+            },
+            "qs_delta": True,
+        }
+    )
+    assert len(tr.xtb_qs_priors) == 1 and len(tr.qs_deltas) == 1
+
+
+def test_transform_rejects_uniform_and_xtb_together():
+    with pytest.raises(ValueError, match="only one of uniform_qs_init"):
+        Transform(
+            {
+                "uniform_qs_init": True,
+                "xtb_qs_prior": {"enabled": True, "atomic_qs_fn": lambda *a, **k: (np.zeros(1), np.zeros(1))},
+            }
+        )
+
+
+def test_datahub_rejects_uniform_in_preprocessings_and_xtb_in_global():
+    from enerzyme.data.datahub import SingleDataHub
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(ValueError, match="do not combine"):
+            SingleDataHub(
+                dump_dir=tmp,
+                data_path=os.path.join(tmp, "nope.aselmdb"),
+                features={"Ra": "Ra", "Za": "Za", "N": "N"},
+                targets={},
+                preprocessings={"uniform_qs_init": True},
+                global_transforms={
+                    "xtb_qs_prior": {
+                        "enabled": True,
+                        "atomic_qs_fn": lambda *a, **k: (np.zeros(1), np.zeros(1)),
+                    }
+                },
+                preload=False,
+            )
+
+
+def test_qs_delta_inverse_recovers_qa_sa():
+    """inverse_transform adds Q_init_a / S_init_a back and writes Qa / Sa."""
+    y = {
+        "Qa": [np.array([0.1, -0.1]), np.array([0.0, 0.0, 0.0])],
+        "Sa": [np.array([0.05, -0.05]), np.array([0.0, 0.0, 0.0])],
+        "Q_init_a": [np.array([0.0, 0.0]), np.array([-1.0 / 3.0, -1.0 / 3.0, -1.0 / 3.0])],
+        "S_init_a": [np.array([0.0, 0.0]), np.array([1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])],
+    }
+    tr = Transform({"qs_delta": True})
+    tr.inverse_transform(y)
+    assert np.allclose(y["Qa"][0], [0.1, -0.1])
+    assert np.allclose(y["Sa"][0], [0.05, -0.05])
+    assert np.allclose(y["Qa"][1], [-1.0 / 3.0, -1.0 / 3.0, -1.0 / 3.0])
+    assert np.allclose(y["Sa"][1], [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+
+
+def test_transform_forward_order_uniform_before_delta_regardless_of_yaml_key_order():
+    """YAML may list qs_delta before uniform_qs_init; forward still applies prior then delta."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([2], dtype=np.int32))
+            g.create_dataset("Za", data=np.array([[6, 6, 0]], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((1, 3, 3), dtype=np.float64))
+            g.create_dataset("Q", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+            g.create_dataset("Qa", data=np.array([[0.1, -0.1, 0.0]], dtype=np.float64))
+            g.create_dataset("Sa", data=np.array([[0.05, -0.05, 0.0]], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            Transform({"qs_delta": True, "uniform_qs_init": True}).transform(g)
+            assert "Q_init_a" in g and "Qa" in g
+            assert "Q_delta_a" not in g and "S_delta_a" not in g
+            assert np.isclose(np.asarray(g["Qa"][0, :2]).sum(), 0.0, atol=1e-9)
+
+
+def test_xtb_prior_uses_ra_frame_count_when_n_compressed():
+    """Compressed N (len=1) must still emit one Q_init_a row per Ra frame."""
+    calls = []
+
+    def fake_atomic(atoms, max_scf_iter=1, **kw):
+        calls.append(len(atoms))
+        n = len(atoms)
+        return np.full(n, 0.1 / n, dtype=np.float64), np.zeros(n, dtype=np.float64)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "t.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("N", data=np.array([3], dtype=np.int32))
+            g.create_dataset("Ra", data=np.zeros((4, 3, 3), dtype=np.float64))
+            g.create_dataset("Za", data=np.array([[6, 6, 6]], dtype=np.int32))
+            g.create_dataset("Q", data=np.array([0.1], dtype=np.float64))
+            g.create_dataset("S", data=np.array([0.0], dtype=np.float64))
+
+        with h5py.File(path, "a") as f:
+            g = f["data"]
+            XTBQSPriorTransform(atomic_qs_fn=fake_atomic).transform(g)
+            qia = np.asarray(g["Q_init_a"][:])
+            assert qia.shape == (4, 3)
+            assert len(calls) == 4
+            assert np.allclose(qia.sum(axis=1), 0.1)
+
+
+def test_datahub_populate_xtb_from_preprocessings(tmp_path):
+    """Populate flags must honor preprocessings, not only global_transforms."""
+    import pickle
+    from pathlib import Path
+
+    from enerzyme.data.datahub import SingleDataHub
+    from enerzyme.data.transform import wants_xtb_qs_prior
+
+    assert wants_xtb_qs_prior({"xtb_qs_prior": {"enabled": True}})
+
+    frames = [
+        {
+            "atom_type": ["C", "O"],
+            "coord": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0]],
+            "total_chrg": 0,
+            "total_spin": 0,
+        }
+    ]
+    pkl = Path(tmp_path) / "qs.pkl"
+    with open(pkl, "wb") as f:
+        pickle.dump(frames, f)
+
+    def fake_atomic(atoms, max_scf_iter=1, **kw):
+        n = len(atoms)
+        return np.zeros(n, dtype=np.float64), np.zeros(n, dtype=np.float64)
+
+    hub = SingleDataHub(
+        dump_dir=str(Path(tmp_path) / "out"),
+        data_path=str(pkl),
+        data_format="pickle",
+        preload=True,
+        neighbor_list="",
+        features={"Ra": "coord", "Za": "atom_type", "Q": "total_chrg", "S": "total_spin", "N": None},
+        targets={},
+        preprocessings={
+            "xtb_qs_prior": {
+                "enabled": True,
+                "atomic_qs_fn": fake_atomic,
+            }
+        },
+        global_transforms=None,
+    )
+    assert hub._populate_xtb_qs_prior
+    assert "Q_init_a" in hub.feature_types and "S_init_a" in hub.feature_types
+    assert "Q_init_a" in hub.features
+
+
+def test_check_xtbml_dependencies_import_error(monkeypatch):
+    import builtins
+    import enerzyme.qm.xtb_population.deps as deps
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "ase" or name.startswith("ase."):
+            raise ImportError("no ase")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="requires ASE"):
+        deps.check_xtbml_dependencies()


### PR DESCRIPTION
## Summary
- Add optional Datahub transforms `xtb_qs_prior` and `pyscf_nao_qs_prior` that populate `Q_init_a` / `S_init_a` from GFN2-xTB+xtbml or GPU4PySCF/PySCF NAO populations (new helper packages under `enerzyme/qm/`).
- Add `qs_delta` to train on residual `Qa`/`Sa` vs the prior, with batch prior passthrough so inverse transform recovers full charges/spins at predict/metric time.
- Document the hooks in the Sphinx data guides, comment examples in `train.yaml`, add optional extras `xtb` / `pyscf_nao`, and cover compressed-frame + DataHub wiring with mock-based pytest (no heavy QM in CI).

## Test plan
- [x] `pytest test/test_xtb_population_transform.py test/test_pyscf_nao_population_transform.py test/test_uniform_qs_init_transform.py` (31 passed)
- [ ] Spot-check YAML comments / docs render for the new transform entries
- [ ] Optional: one-frame smoke with real `tblite` or `pyscf` if available locally


Made with [Cursor](https://cursor.com)