### PR TITLE
Modularize SchNet RBF/cutoff and add PyG parity tests

### DIFF
--- a/docs/getting_started/training.rst
+++ b/docs/getting_started/training.rst
@@ -135,7 +135,10 @@ Final Modelhub configuration
                     Bohr_in_R: 0.5291772108
                 layers:
                   - name: RangeSeparation
-                  - name: GaussianSmearing
+                  - name: GaussianRBF
+                    params:
+                        flavor: SchNet
+                        apply_cutoff_fn: false
                   - name: RandomAtomEmbedding
                   - name: Core
                     params:

--- a/docs/user_guide/models/architecture_catalog.rst
+++ b/docs/user_guide/models/architecture_catalog.rst
@@ -141,7 +141,7 @@ Selection guidelines
     production default is :code:`SimpleReadout` with :code:`head_type: two_layer` after 0e
     extract, optional :code:`EquiformerGraphAttentionReadout`); prefer smaller irreps /
     fewer layers for enzyme-scale clusters. EquiformerV2 uses SO(2)-reduced attention
-    (default :code:`GaussianSmearing` + :code:`atom_feature` / :code:`atom_sphere_feature`)
+    (default :code:`GaussianRBF` with SchNet width / no RBF envelope + :code:`atom_feature` / :code:`atom_sphere_feature`)
     and scales more easily to higher :code:`lmax` with truncated :code:`mmax`.
     EquiformerV3 adds merged LN, SwiGLU-S², and smooth-cutoff attention on the same
     latent contract (default :code:`norm_type: merge_layer_norm`,

--- a/docs/user_guide/models/layer_stack.rst
+++ b/docs/user_guide/models/layer_stack.rst
@@ -12,7 +12,7 @@ From :code:`enerzyme/models/layers/`:
     :code:`DistanceLayer`, :code:`RangeSeparationLayer`, :code:`RadiusGraphLayer`
 
 **Radial basis**
-    :code:`GaussianSmearing`, :code:`ExponentialGaussianRBFLayer`, :code:`ExponentialBernsteinRBFLayer`, :code:`BesselRBFLayer`, :code:`BernsteinRBFLayer`, :code:`SincRBFLayer`
+    :code:`GaussianRBFLayer` (``flavor``: PhysNet / SchNet; optional ``apply_cutoff_fn``), :code:`ExponentialGaussianRBFLayer`, :code:`ExponentialBernsteinRBFLayer`, :code:`BesselRBFLayer`, :code:`BernsteinRBFLayer`, :code:`SincRBFLayer`
 
 **Embeddings**
     :code:`RandomAtomEmbedding`, :code:`NuclearEmbedding`, :code:`ElectronicEmbedding`, :code:`ChargeSpinEmbedding` (SO3LR-style), :code:`ScalarDenseEmbedding`, :code:`GatherAtomEmbedding` (optional :code:`scale_by_sqrt_count` for SO3LR)

--- a/enerzyme/config/e2former_layers_example.yaml
+++ b/enerzyme/config/e2former_layers_example.yaml
@@ -17,7 +17,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/e2former_lsr_layers_example.yaml
+++ b/enerzyme/config/e2former_lsr_layers_example.yaml
@@ -22,7 +22,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/e2former_v2_layers_example.yaml
+++ b/enerzyme/config/e2former_v2_layers_example.yaml
@@ -19,7 +19,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/equiformer_v2_ffn_readout_example.yaml
+++ b/enerzyme/config/equiformer_v2_ffn_readout_example.yaml
@@ -20,7 +20,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/equiformer_v2_layers_example.yaml
+++ b/enerzyme/config/equiformer_v2_layers_example.yaml
@@ -17,7 +17,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/equiformer_v2_shallow_ensemble_example.yaml
+++ b/enerzyme/config/equiformer_v2_shallow_ensemble_example.yaml
@@ -17,7 +17,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/equiformer_v3_layers_example.yaml
+++ b/enerzyme/config/equiformer_v3_layers_example.yaml
@@ -17,7 +17,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/config/train.yaml
+++ b/enerzyme/config/train.yaml
@@ -418,9 +418,10 @@ Modelhub:
         Bohr_in_R: 0.5291772108
       layers:
         - name: RangeSeparation             
-        - name: GaussianSmearing            # Gaussian smearing radial basis function
+        - name: GaussianRBF                 # Gaussian RBF (SchNet width; no envelope on RBF)
           params:                           # num_rbf, cutoff_sr in build_params
-            cuton: 0.0                      # cuton distance of the Gaussian smearing function
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding        
         - name: Core                        # SchNet Core
           params:                           # dim_embedding, num_rbf in build_params
@@ -802,7 +803,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:
@@ -846,7 +850,10 @@ Modelhub:
         cutoff_fn: polynomial
       layers:
         - name: RangeSeparation
-        - name: GaussianSmearing
+        - name: GaussianRBF
+          params:
+            flavor: SchNet
+            apply_cutoff_fn: false
         - name: RandomAtomEmbedding
         - name: Core
           params:

--- a/enerzyme/models/e2former/core.py
+++ b/enerzyme/models/e2former/core.py
@@ -41,7 +41,7 @@ DEFAULT_BUILD_PARAMS = {
 
 DEFAULT_LAYER_PARAMS = [
     {"name": "RangeSeparation"},
-    {"name": "GaussianSmearing"},
+    {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
     {"name": "RandomAtomEmbedding"},
     {
         "name": "Core",

--- a/enerzyme/models/e2former/v2.py
+++ b/enerzyme/models/e2former/v2.py
@@ -19,7 +19,7 @@ DEFAULT_BUILD_PARAMS = dict(_V1_BUILD)
 
 DEFAULT_LAYER_PARAMS = [
     {"name": "RangeSeparation"},
-    {"name": "GaussianSmearing"},
+    {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
     {"name": "RandomAtomEmbedding"},
     {
         "name": "Core",

--- a/enerzyme/models/equiformer/core.py
+++ b/enerzyme/models/equiformer/core.py
@@ -256,7 +256,6 @@ class EquiformerCore(BaseFFCore):
                 elif isinstance(layer, (EquiformerNodeEmbedding, BaseAtomEmbedding)):
                     self.atom_embedding = layer
                 elif isinstance(layer, BaseRBF) or layer.__class__.__name__ in {
-                    "GaussianSmearing",
                     "ExpNormalSmearing",
                 }:
                     self.radial_basis_function = layer

--- a/enerzyme/models/equiformer_v2/core.py
+++ b/enerzyme/models/equiformer_v2/core.py
@@ -47,7 +47,7 @@ DEFAULT_BUILD_PARAMS = {
 
 DEFAULT_LAYER_PARAMS = [
     {"name": "RangeSeparation"},
-    {"name": "GaussianSmearing"},
+    {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
     {"name": "RandomAtomEmbedding"},
     {
         "name": "Core",

--- a/enerzyme/models/equiformer_v3/core.py
+++ b/enerzyme/models/equiformer_v3/core.py
@@ -45,7 +45,7 @@ DEFAULT_BUILD_PARAMS = {
 
 DEFAULT_LAYER_PARAMS = [
     {"name": "RangeSeparation"},
-    {"name": "GaussianSmearing"},
+    {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
     {"name": "RandomAtomEmbedding"},
     {
         "name": "Core",

--- a/enerzyme/models/layers/__init__.py
+++ b/enerzyme/models/layers/__init__.py
@@ -3,7 +3,7 @@ from .geometry import DistanceLayer, RangeSeparationLayer
 from .rbf import (
     BaseRBF, 
     ExponentialGaussianRBFLayer, ExponentialBernsteinRBFLayer,
-    GaussianRBFLayer, BernsteinRBFLayer, SincRBFLayer, BesselRBFLayer, GaussianSmearing,
+    GaussianRBFLayer, BernsteinRBFLayer, SincRBFLayer, BesselRBFLayer,
     ExpNormalSmearing,
 )
 from .atom_embedding import BaseAtomEmbedding, RandomAtomEmbedding, NuclearEmbedding

--- a/enerzyme/models/layers/rbf.py
+++ b/enerzyme/models/layers/rbf.py
@@ -16,17 +16,32 @@ class BaseRBF(BaseFFLayer):
         self,
         num_rbf: int,
         cutoff_sr: float,
-        cutoff_fn: CUTOFF_KEY_TYPE,
+        cutoff_fn: Optional[CUTOFF_KEY_TYPE] = None,
+        apply_cutoff_fn: bool = True,
     ) -> None:
-        super().__init__(input_fields={"Dij_sr", "cutoff_values_sr"}, output_fields={"rbf"})
+        input_fields = {"Dij_sr"}
+        if apply_cutoff_fn:
+            input_fields.add("cutoff_values_sr")
+        super().__init__(input_fields=input_fields, output_fields={"rbf"})
         self.num_rbf = num_rbf
         self.cutoff_sr = cutoff_sr
-        self.cutoff_fn = CUTOFF_REGISTER[cutoff_fn]
+        self.apply_cutoff_fn = apply_cutoff_fn
+        if apply_cutoff_fn:
+            if cutoff_fn is None:
+                raise TypeError("cutoff_fn is required when apply_cutoff_fn=True")
+            self.cutoff_fn = CUTOFF_REGISTER[cutoff_fn]
+        else:
+            self.cutoff_fn = (
+                CUTOFF_REGISTER[cutoff_fn] if cutoff_fn is not None else None
+            )
 
     def get_rbf(self, Dij_sr: Tensor, cutoff_values_sr: Optional[Tensor]=None, **kwargs) -> Tensor:
+        rbf = self._get_rbf(Dij_sr)
+        if not self.apply_cutoff_fn:
+            return rbf
         if cutoff_values_sr is None:
             cutoff_values_sr = self.cutoff_fn(Dij_sr, cutoff=self.cutoff_sr)
-        return cutoff_values_sr.view(-1, 1) * self._get_rbf(Dij_sr)
+        return cutoff_values_sr.view(-1, 1) * rbf
 
     @abstractmethod
     def _get_rbf(self, Dij: Tensor) -> Tensor:
@@ -37,35 +52,57 @@ class GaussianRBFLayer(BaseRBF):
     """
     Radial basis functions based on Gaussian functions:
 
-    .. math:: g_i(x) = \\exp(-\\mathtt{width}\\cdot(x-\\mathtt{center}_i)^2)
+    .. math:: g_i(x) = \\exp(\\mathtt{coeff}\\cdot(x-\\mathtt{center}_i)^2)
 
-    Here, :math:`i` takes values from :math:`0` to :math:`\\mathtt{num\\_rbf}-1`. The `center` is chosen
-    to optimally span the range :math:`x\\in (0,\\mathtt{cutoff}]` and the :math:`\\mathtt{width}` parameter is
-    selected to give optimal overlap between adjacent Gaussian functions.
+    Here, :math:`i` takes values from :math:`0` to :math:`\\mathtt{num\\_rbf}-1`.
+    Centers span :math:`[0, \\mathtt{cutoff}]`. ``flavor`` only selects how
+    ``coeff`` (Gaussian width) is initialized:
 
-    Arguments:
-        num_basis_functions (int):
-            Number of radial basis functions.
-        cutoff (float):
-            Cutoff radius.
+    * ``PhysNet`` (default): ``coeff = -num_rbf / cutoff``
+    * ``SchNet``: ``coeff = -0.5 / Δ²`` with ``Δ = cutoff / (num_rbf - 1)``
+      (PyG Gaussian smearing convention)
+
+    Cutoff envelope application is controlled separately by ``apply_cutoff_fn``.
     """
 
-    def __init__(self, num_rbf: int, cutoff_sr: float, cutoff_fn: CUTOFF_KEY_TYPE = "bump") -> None:
-        """ Initializes the GaussianFunctions class. """
-        super().__init__(num_rbf, cutoff_sr, cutoff_fn)
-        self.register_buffer(
-            "center",
-            torch.linspace(0, cutoff_sr, num_rbf, dtype=torch.float64),
-        )
-        self.register_buffer(
-            "width", torch.tensor(num_rbf / cutoff_sr, dtype=torch.float64)
-        )
+    def __init__(
+        self,
+        num_rbf: int,
+        cutoff_sr: float,
+        cutoff_fn: Optional[CUTOFF_KEY_TYPE] = "bump",
+        apply_cutoff_fn: bool = True,
+        flavor: Literal["PhysNet", "SchNet"] = "PhysNet",
+    ) -> None:
+        if apply_cutoff_fn and cutoff_fn is None:
+            cutoff_fn = "bump"
+        super().__init__(num_rbf, cutoff_sr, cutoff_fn, apply_cutoff_fn=apply_cutoff_fn)
+        self.flavor = flavor
+        if flavor == "PhysNet":
+            # float64 buffers match historical SpookyNet / PhysNet parity.
+            self.register_buffer(
+                "center",
+                torch.linspace(0, cutoff_sr, num_rbf, dtype=torch.float64),
+            )
+            width = torch.tensor(num_rbf / cutoff_sr, dtype=torch.float64)
+            self.register_buffer("width", width)
+            self.register_buffer("coeff", -width)
+        elif flavor == "SchNet":
+            # Default dtype matches PyG GaussianSmearing offsets / coeff.
+            center = torch.linspace(0, cutoff_sr, num_rbf)
+            self.register_buffer("center", center)
+            coeff = torch.tensor(
+                -0.5 / (center[1] - center[0]).item() ** 2
+            )
+            self.register_buffer("coeff", coeff)
+            self.register_buffer("width", -coeff)
+        else:
+            raise ValueError(
+                f"Unknown GaussianRBF flavor {flavor!r}; expected 'PhysNet' or 'SchNet'"
+            )
 
     def _get_rbf(self, Dij: Tensor) -> Tensor:
         """
-        Evaluates radial basis functions given distances and the corresponding
-        values of a cutoff function (must be consistent with cutoff value
-        passed at initialization).
+        Evaluates radial basis functions given distances.
         N: Number of input values.
         num_basis_functions: Number of radial basis functions.
 
@@ -77,9 +114,7 @@ class GaussianRBFLayer(BaseRBF):
             rbf (FloatTensor [N, num_basis_functions]):
                 Values of the radial basis functions for the distances r.
         """
-        return torch.exp(
-            -self.width * (Dij.view(-1, 1) - self.center) ** 2
-        )
+        return torch.exp(self.coeff * (Dij.view(-1, 1) - self.center) ** 2)
 
 
 class BernsteinRBFLayer(BaseRBF):
@@ -447,23 +482,6 @@ class BesselRBFLayer(BaseRBF):
     def _get_rbf(self, x: Tensor) -> Tensor:  # [..., 1]
         numerator = torch.sin(self.bessel_weights.view(1, -1) * x.view(-1, 1))  # [..., num_basis]
         return self.prefactor * (numerator / x.view(-1, 1))
-
-
-class GaussianSmearing(BaseFFLayer):
-    def __init__(
-        self,
-        num_rbf: int,
-        cutoff_sr: float,
-        cuton: float=0.0,
-    ):
-        super().__init__(input_fields={"Dij_sr"}, output_fields={"rbf"})
-        offset = torch.linspace(cuton, cutoff_sr, num_rbf)
-        self.coeff = -0.5 / (offset[1] - offset[0]).item() ** 2
-        self.register_buffer('offset', offset)
-
-    def get_rbf(self, Dij_sr: Tensor) -> Tensor:
-        dist = Dij_sr.view(-1, 1) - self.offset.view(1, -1)
-        return torch.exp(self.coeff * torch.pow(dist, 2))
 
 
 class ExpNormalSmearing(BaseFFLayer):

--- a/enerzyme/models/schnet/core.py
+++ b/enerzyme/models/schnet/core.py
@@ -22,12 +22,8 @@ DEFAULT_BUILD_PARAMS = {
     'Bohr_in_R': 0.5291772108
 }
 DEFAULT_LAYER_PARAMS = [{'name': 'RangeSeparation'},
- {'name': 'GaussianSmearing',
-  'params': {'no_basis_at_infinity': False,
-   'init_alpha': 1,
-   'exp_weighting': False,
-   'learnable_shape': True,
-   'init_width_flavor': 'PhysNet'}},
+ {'name': 'GaussianRBF',
+  'params': {'flavor': 'SchNet', 'apply_cutoff_fn': False}},
  {'name': 'RandomAtomEmbedding'},
  {'name': 'Core',
   'params': {'hidden_channels': 128,

--- a/enerzyme/models/schnet/interaction.py
+++ b/enerzyme/models/schnet/interaction.py
@@ -1,9 +1,8 @@
-from math import pi as PI
-import torch
 from torch import Tensor
 from torch.nn import Module, Sequential, Linear, init
 from torch_geometric.nn import MessagePassing
 from ..activation import ACTIVATION_KEY_TYPE, ACTIVATION_PARAM_TYPE, get_activation_fn
+from ..cutoff import cosine_transition
 
 
 class InteractionBlock(Module):
@@ -66,7 +65,7 @@ class CFConv(MessagePassing):
 
     def forward(self, x: Tensor, edge_index: Tensor, edge_weight: Tensor,
                 edge_attr: Tensor) -> Tensor:
-        C = 0.5 * (torch.cos(edge_weight * PI / self.cutoff) + 1.0)
+        C = cosine_transition(edge_weight, cutoff=self.cutoff)
         W = self.nn(edge_attr) * C.view(-1, 1)
 
         x = self.lin1(x)

--- a/example/L3-COMT-aselmdb-smoke/config/train_otf_batch_schnet.yaml
+++ b/example/L3-COMT-aselmdb-smoke/config/train_otf_batch_schnet.yaml
@@ -34,9 +34,10 @@ Modelhub:
         num_rbf: 8
       layers:
       - name: RangeSeparation
-      - name: GaussianSmearing
+      - name: GaussianRBF
         params:
-          cuton: 0.0
+          flavor: SchNet
+          apply_cutoff_fn: false
       - name: RandomAtomEmbedding
       - name: Core
         params:

--- a/test/schnet_parity_utils.py
+++ b/test/schnet_parity_utils.py
@@ -1,0 +1,65 @@
+"""Helpers for SchNet numerical parity against torch_geometric.nn.models.schnet."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+import torch
+from numpy.testing import assert_allclose
+from torch import Tensor
+from torch.nn import Module
+
+pytest.importorskip("torch_geometric")
+
+PARITY_HPARAMS = {
+    "hidden_channels": 32,
+    "num_filters": 32,
+    "num_gaussians": 16,
+    "num_interactions": 2,
+    "cutoff": 5.0,
+}
+
+
+def assert_close(
+    a: Tensor,
+    b: Tensor,
+    atol: float = 1e-5,
+    rtol: float = 1e-5,
+    err_msg: str = "",
+) -> None:
+    assert_allclose(
+        a.detach().cpu().numpy(),
+        b.detach().cpu().numpy(),
+        atol=atol,
+        rtol=rtol,
+        err_msg=err_msg,
+    )
+
+
+def copy_state_dict(dst: Module, src: Module) -> None:
+    dst.load_state_dict(src.state_dict())
+
+
+def make_parity_graph(
+    num_atoms: int = 6,
+    cutoff: float = PARITY_HPARAMS["cutoff"],
+    seed: int = 0,
+    dtype: torch.dtype = torch.float64,
+) -> Dict[str, Tensor]:
+    """Build a shared radius graph for Enerzyme / PyG SchNet parity."""
+    from torch_geometric.nn.models.schnet import RadiusInteractionGraph
+
+    torch.manual_seed(seed)
+    z = torch.randint(1, 10, (num_atoms,), dtype=torch.long)
+    pos = torch.randn(num_atoms, 3, dtype=dtype)
+    batch = torch.zeros(num_atoms, dtype=torch.long)
+    graph = RadiusInteractionGraph(cutoff=cutoff, max_num_neighbors=32)
+    edge_index, edge_weight = graph(pos, batch)
+    return {
+        "z": z,
+        "pos": pos,
+        "batch": batch,
+        "edge_index": edge_index,
+        "edge_weight": edge_weight.to(dtype),
+    }

--- a/test/test_e2former_core.py
+++ b/test/test_e2former_core.py
@@ -117,7 +117,7 @@ def test_e2former_energy_invariance_and_force_equivariance():
         "e2former",
         layer_params=[
             {"name": "RangeSeparation"},
-            {"name": "GaussianSmearing"},
+            {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
             {"name": "RandomAtomEmbedding"},
             {
                 "name": "Core",
@@ -191,7 +191,7 @@ def test_e2former_energy_translation_invariance():
         "e2former",
         layer_params=[
             {"name": "RangeSeparation"},
-            {"name": "GaussianSmearing"},
+            {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
             {"name": "RandomAtomEmbedding"},
             {
                 "name": "Core",
@@ -323,7 +323,7 @@ def test_e2former_dense_graph_respects_max_neighbors():
         "e2former",
         layer_params=[
             {"name": "RangeSeparation"},
-            {"name": "GaussianSmearing"},
+            {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
             {"name": "RandomAtomEmbedding"},
             {
                 "name": "Core",

--- a/test/test_e2former_lsr_core.py
+++ b/test/test_e2former_lsr_core.py
@@ -77,7 +77,7 @@ def _tiny_lsr_layer_params(**core_overrides):
     params.update(core_overrides)
     return [
         {"name": "RangeSeparation"},
-        {"name": "GaussianSmearing"},
+        {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
         {"name": "RandomAtomEmbedding"},
         {"name": "Core", "params": params},
         {

--- a/test/test_e2former_v2_core.py
+++ b/test/test_e2former_v2_core.py
@@ -92,7 +92,7 @@ def test_e2former_v2_build_model_energy_force_finite():
         "e2former_v2",
         layer_params=[
             {"name": "RangeSeparation"},
-            {"name": "GaussianSmearing"},
+            {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
             {"name": "RandomAtomEmbedding"},
             {
                 "name": "Core",
@@ -158,7 +158,7 @@ def test_e2former_v2_energy_invariance_and_force_equivariance():
         "e2former_v2",
         layer_params=[
             {"name": "RangeSeparation"},
-            {"name": "GaussianSmearing"},
+            {"name": "GaussianRBF", "params": {"flavor": "SchNet", "apply_cutoff_fn": False}},
             {"name": "RandomAtomEmbedding"},
             {
                 "name": "Core",

--- a/test/test_schnet_parity_ops.py
+++ b/test/test_schnet_parity_ops.py
@@ -1,0 +1,172 @@
+"""Operator-level numerical parity vs torch_geometric SchNet."""
+
+from __future__ import annotations
+
+import math
+import sys
+
+import torch
+
+sys.path.extend(["..", "."])
+
+from schnet_parity_utils import (  # noqa: E402
+    PARITY_HPARAMS,
+    assert_close,
+    copy_state_dict,
+    make_parity_graph,
+)
+
+
+def test_gaussian_rbf_schnet_flavor_matches_pyg():
+    from torch_geometric.nn.models.schnet import GaussianSmearing as PygSmearing
+
+    from enerzyme.models.layers.rbf import GaussianRBFLayer
+
+    hp = PARITY_HPARAMS
+    dtype = torch.float64
+    torch.manual_seed(0)
+    d = torch.rand(48, dtype=dtype) * hp["cutoff"]
+
+    pyg = PygSmearing(0.0, hp["cutoff"], hp["num_gaussians"]).to(dtype)
+    ours = GaussianRBFLayer(
+        num_rbf=hp["num_gaussians"],
+        cutoff_sr=hp["cutoff"],
+        flavor="SchNet",
+        apply_cutoff_fn=False,
+    ).to(dtype)
+
+    assert_close(ours.center, pyg.offset, atol=1e-12, rtol=1e-12, err_msg="centers")
+    assert_close(
+        ours.get_rbf(d),
+        pyg(d),
+        atol=1e-6,
+        rtol=1e-5,
+        err_msg="rbf",
+    )
+
+
+def test_cosine_transition_matches_pyg_inline():
+    from enerzyme.models.cutoff import cosine_transition
+
+    cutoff = PARITY_HPARAMS["cutoff"]
+    dtype = torch.float64
+    d = torch.linspace(0.0, cutoff, 41, dtype=dtype)
+    pyg = 0.5 * (torch.cos(d * math.pi / cutoff) + 1.0)
+    ours = cosine_transition(d, cutoff=cutoff)
+    assert_close(ours, pyg, atol=1e-7, rtol=1e-7, err_msg="cosine")
+
+
+def test_interaction_block_matches_pyg():
+    from torch_geometric.nn.models.schnet import InteractionBlock as PygIB
+
+    from enerzyme.models.schnet.interaction import InteractionBlock as EzIB
+
+    hp = PARITY_HPARAMS
+    dtype = torch.float64
+    graph = make_parity_graph(dtype=dtype)
+    edge_index = graph["edge_index"]
+    edge_weight = graph["edge_weight"]
+    num_nodes = graph["pos"].size(0)
+
+    torch.manual_seed(1)
+    pyg = PygIB(
+        hp["hidden_channels"],
+        hp["num_gaussians"],
+        hp["num_filters"],
+        hp["cutoff"],
+    ).to(dtype)
+    ez = EzIB(
+        hp["hidden_channels"],
+        hp["num_gaussians"],
+        hp["num_filters"],
+        hp["cutoff"],
+    ).to(dtype)
+    copy_state_dict(ez, pyg)
+
+    from torch_geometric.nn.models.schnet import GaussianSmearing as PygSmearing
+
+    edge_attr = PygSmearing(0.0, hp["cutoff"], hp["num_gaussians"]).to(dtype)(
+        edge_weight
+    )
+    x = torch.randn(num_nodes, hp["hidden_channels"], dtype=dtype)
+
+    assert_close(
+        ez(x, edge_index, edge_weight, edge_attr),
+        pyg(x, edge_index, edge_weight, edge_attr),
+        atol=1e-5,
+        rtol=1e-5,
+        err_msg="InteractionBlock",
+    )
+
+
+def test_residual_interaction_stack_matches_pyg():
+    from torch_geometric.nn.models.schnet import GaussianSmearing as PygSmearing
+    from torch_geometric.nn.models.schnet import InteractionBlock as PygIB
+    from torch.nn import ModuleList
+
+    from enerzyme.models.layers.rbf import GaussianRBFLayer
+    from enerzyme.models.schnet.core import SchNetCore
+
+    hp = PARITY_HPARAMS
+    dtype = torch.float64
+    graph = make_parity_graph(dtype=dtype, seed=2)
+    edge_index = graph["edge_index"]
+    edge_weight = graph["edge_weight"]
+    num_nodes = graph["pos"].size(0)
+
+    torch.manual_seed(3)
+    pyg_blocks = ModuleList(
+        [
+            PygIB(
+                hp["hidden_channels"],
+                hp["num_gaussians"],
+                hp["num_filters"],
+                hp["cutoff"],
+            )
+            for _ in range(hp["num_interactions"])
+        ]
+    ).to(dtype)
+
+    ez_core = SchNetCore(
+        hidden_channels=hp["hidden_channels"],
+        dim_embedding=hp["num_filters"],
+        num_interactions=hp["num_interactions"],
+        num_rbf=hp["num_gaussians"],
+        cutoff_sr=hp["cutoff"],
+        output_mode="feature",
+    ).to(dtype)
+    for ez_block, pyg_block in zip(ez_core.interactions, pyg_blocks):
+        copy_state_dict(ez_block, pyg_block)
+
+    rbf_layer = GaussianRBFLayer(
+        num_rbf=hp["num_gaussians"],
+        cutoff_sr=hp["cutoff"],
+        flavor="SchNet",
+        apply_cutoff_fn=False,
+    ).to(dtype)
+    edge_attr = rbf_layer.get_rbf(edge_weight)
+    # Cross-check against PyG smearing on the same edges.
+    pyg_attr = PygSmearing(0.0, hp["cutoff"], hp["num_gaussians"]).to(dtype)(
+        edge_weight
+    )
+    assert_close(edge_attr, pyg_attr, atol=1e-6, rtol=1e-5, err_msg="edge_attr")
+
+    h0 = torch.randn(num_nodes, hp["hidden_channels"], dtype=dtype)
+    h_pyg = h0.clone()
+    for block in pyg_blocks:
+        h_pyg = h_pyg + block(h_pyg, edge_index, edge_weight, edge_attr)
+
+    out = ez_core.get_output(
+        idx_i_sr=edge_index[0],
+        idx_j_sr=edge_index[1],
+        Dij_sr=edge_weight,
+        rbf=edge_attr,
+        atom_embedding=h0.clone(),
+    )
+    assert_close(
+        out["atom_feature"],
+        h_pyg,
+        atol=1e-5,
+        rtol=1e-5,
+        err_msg="residual interaction stack",
+    )


### PR DESCRIPTION
## Summary
- Add `BaseRBF.apply_cutoff_fn` (default `True`) so RBF layers can skip envelope multiplication; SchNet-style stacks use `False` because CFConv already applies the cosine cutoff.
- Unify former `GaussianSmearing` into `GaussianRBFLayer` via `flavor` (`PhysNet` / `SchNet`) that only controls width initialization; remove the public `GaussianSmearing` RBF export and migrate configs/defaults/docs/tests to `GaussianRBF` + SchNet params.
- Route SchNet `CFConv` through shared `cosine_transition`, and add `test_schnet_parity_ops.py` against installed `torch_geometric` SchNet (RBF, cosine, InteractionBlock, residual feature stack).

## Test plan
- [x] `pytest test/test_schnet_parity_ops.py -v` in `barw-dev`
- [x] `pytest test/test_spookynet.py::test_gaussian_functions -v` (PhysNet flavor unchanged)
- [x] `build_model("SchNet")` smoke with default layer stack
- [ ] CI on PR


Made with [Cursor](https://cursor.com)