### PR TITLE
Add async Multiwfn atomic charges to annotate

### DIFF
--- a/docs/getting_started/qm_annotation.rst
+++ b/docs/getting_started/qm_annotation.rst
@@ -12,7 +12,7 @@ Basic command
 
 Arguments:
 
-- :code:`-c` — annotation config (:code:`Supplier` + :code:`QMDriver`)
+- :code:`-c` — annotation config (:code:`Supplier` + :code:`QMDriver` + optional :code:`Multiwfn`)
 - :code:`-o` — output directory
 - :code:`-t` — scratch directory for QM jobs
 - :code:`-s`, :code:`-e` — slice of molecules from the supplier (0-based start, exclusive end; :code:`-1` for all)
@@ -32,6 +32,12 @@ Configuration
         keep_stdout: false
         clean_tmp: true
         n_processes: 1
+    Multiwfn:
+        enabled: false
+        executable: Multiwfn_noGUI
+        charge_method: 1.2cm5
+        n_threads: 12
+        n_processes: 1
 
 Supplier
 ^^^^^^^^
@@ -49,8 +55,15 @@ The reference driver targets **TeraChem**. Basis, functional, and solvent live i
 
 Results are stored with ASE :code:`SinglePointCalculator` plus :code:`charge` / :code:`spin` / :code:`index` in row data so Datahub can reload them as :code:`aselmdb`. Re-running annotate **skips** completed :code:`index` rows (and retries incomplete reservations). For pickle output, set :code:`dump_single_run: true` (default) to cache :code:`single_run/<index>.pkl` and skip finished structures the same way.
 
+Multiwfn atomic charges (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set top-level :code:`Multiwfn.enabled: true` to compute atomic charges from each TeraChem molden **asynchronously**. GPU TeraChem workers copy a valid molden and immediately take the next structure; a separate CPU process pool runs :code:`Multiwfn_noGUI`. Charges (``.chg`` column 5) are stored as :code:`Qa` (ASE calculator :code:`charges`; pickle key :code:`Qa`, or a :code:`pickle_fields.Qa` rename such as :code:`chrg`).
+
+The job script must :code:`module load` a noGUI Multiwfn build **and** TeraChem. GPU nodes are assumed to have enough CPUs for both. Keep :code:`n_threads * n_processes` within the node CPU budget. Default :code:`charge_method` is :code:`1.2cm5` (menu :code:`7 / -16 / 1 / y`). Hirshfeld-I, RESP, CHELPG, and AIM need extra prompts — pass :code:`menu_inputs`.
+
 .. caution::
-    Prepare TeraChem and RDKit before running :code:`annotate`. These are not part of the core Enerzyme install.
+    Prepare TeraChem, Multiwfn (if enabled), and RDKit before running :code:`annotate`. These are not part of the core Enerzyme install.
 
 Integrating labeled data into training
 --------------------------------------

--- a/docs/user_guide/workflows/qm_annotation.rst
+++ b/docs/user_guide/workflows/qm_annotation.rst
@@ -28,6 +28,11 @@ Configuration
         keep_stdout: false
         clean_tmp: true
         n_processes: 8
+    Multiwfn:
+        enabled: false
+        charge_method: 1.2cm5
+        n_threads: 12
+        n_processes: 1
 
 Suppliers
 ---------
@@ -52,6 +57,17 @@ QMDriver options
 - :code:`keep_stdout` / :code:`keep_molden` — retain QC logs (:code:`keep_output` is a deprecated alias for :code:`keep_stdout`)
 - :code:`clean_tmp` — remove scratch after success
 
+Multiwfn (optional)
+-------------------
+
+Top-level :code:`Multiwfn` is independent of :code:`QMDriver` so unused keys are not swallowed by the TeraChem kwargs warning. When :code:`enabled: true`:
+
+- Each finished TeraChem job stages ``moldens/<index>.molden`` and **enqueues** Multiwfn without blocking the GPU worker.
+- :code:`n_processes` Multiwfn workers run concurrently; each uses :code:`n_threads` OpenMP threads (``-nt`` and ``OMP_NUM_THREADS``). Default is one worker.
+- Workers write ``chrg-<method>/<index>.chg`` only. After TeraChem **and** Multiwfn finish, the parent merges charges into the ASE LMDB / pickle as :code:`Qa`.
+- :code:`charge_method` (default :code:`1.2cm5`): :code:`hirshfeld`, :code:`vdd`, :code:`mulliken`, :code:`lowdin`, :code:`scpa`, :code:`adch`, :code:`cm5`, :code:`1.2cm5`, :code:`mbis`. Override the whole menu with :code:`menu_inputs`.
+- Resume: energy-complete rows skip TeraChem; missing :code:`Qa` with a surviving molden runs Multiwfn only. Load a noGUI Multiwfn module in the Slurm script (Enerzyme does not call :code:`module load`). Keep :code:`n_threads * n_processes` at or below the node's CPU count.
+
 Legacy template keys (:code:`bs`, :code:`xc`, :code:`pcm`, …) are ignored with a warning — put them in :code:`template_input_file`. Unknown YAML keys are also warned (they used to be swallowed by :code:`**kwargs`).
 
 For PCM, put :code:`pcm_radii_file <name>` in the template (path relative to the template file is fine). :code:`TeraChemDriver` copies that file into the per-job tmp directory so host absolute paths are not required in committed configs.
@@ -61,13 +77,14 @@ Resume / skip completed
 
 - **Pickle** with :code:`dump_single_run: true` (default): each finished structure is written to :code:`<out>/<supplier>/single_run/<index>.pkl`. A later :code:`annotate` run loads those files instead of re-running QM, then rewrites the aggregate :code:`.pkl`.
 - **ASE LMDB**: rows are keyed by structure :code:`index`. If a completed row (calculator energy present) already exists, that structure is skipped. Orphan reserved rows without energy are cleared so a crashed job can continue.
+- **Multiwfn**: if energy is present but :code:`Qa` is missing, TeraChem is skipped and the existing molden is enqueued. If both energy and a ``.chg`` / calculator charges are present, the structure is skipped entirely.
 
 Output schema
 -------------
 
 **ASE LMDB (default):** each structure is an ASE :code:`Atoms` row with calculator energy/forces/(charges/dipole) and :code:`data` fields :code:`charge`, :code:`spin`, :code:`index`. Load with :code:`Datahub.data_format: aselmdb` and **identity** maps (:code:`E`, :code:`Fa`, :code:`M2`, …); see :doc:`/user_guide/data/dataset_formats`.
 
-**Pickle (default):** list of dicts with standard names :code:`E` / :code:`Fa` (Hartree), :code:`M2`, :code:`Ra`, :code:`Za`, :code:`Q`, :code:`S`, :code:`N`, :code:`index`. With :code:`pickle_fields`, keys are renamed for Enerzymette (:code:`energy` / :code:`grad` / :code:`dipole` / …).
+**Pickle (default):** list of dicts with standard names :code:`E` / :code:`Fa` (Hartree), :code:`M2`, :code:`Ra`, :code:`Za`, :code:`Q`, :code:`S`, :code:`N`, :code:`index`, and :code:`Qa` when Multiwfn is enabled. With :code:`pickle_fields`, keys are renamed for Enerzymette (:code:`energy` / :code:`grad` / :code:`dipole` / …); add :code:`Qa: chrg` to keep the NNP4MTase charge key.
 
 Merging into training
 ---------------------
@@ -80,6 +97,7 @@ Environment
 -----------
 
 - :code:`terachem` on :code:`PATH` with valid license
+- :code:`Multiwfn_noGUI` on :code:`PATH` when :code:`Multiwfn.enabled` is true (cluster: ``module load multiwfn/v260410-noGui`` or ``multiwfn/v3.8-noGui-dev``)
 - PCM radius file when the template uses :code:`pcm_radii read` (prefer a file next to the template; see above)
 - RDKit for SDF parsing
 

--- a/enerzyme/annotate.py
+++ b/enerzyme/annotate.py
@@ -7,9 +7,16 @@ class QMAnnotate:
         self.driver_config = config["QMDriver"]
         self.supplier_config = config["Supplier"]
         supplier = get_supplier(**self.supplier_config, start=start, end=end)
+        multiwfn_config = config["Multiwfn"] if "Multiwfn" in config else None
         if self.driver_config["engine"].lower() == "terachem":
             from .qm.qm_driver import TeraChemDriver
-            self.driver = TeraChemDriver(supplier=supplier, tmp_dir=tmp_dir, output_dir=out_dir, **self.driver_config)
+            self.driver = TeraChemDriver(
+                supplier=supplier,
+                tmp_dir=tmp_dir,
+                output_dir=out_dir,
+                multiwfn_config=multiwfn_config,
+                **self.driver_config,
+            )
 
     def drive(self):
         self.driver.run()

--- a/enerzyme/config/annotate.yaml
+++ b/enerzyme/config/annotate.yaml
@@ -23,3 +23,21 @@ QMDriver:
   n_processes: 1                                    # parallel QM submissions
   n_gpus: 1                                         # GPUs for TeraChem; <1 means use all
   terachem_args: [terachem]                         # executable prefix
+
+# Optional CPU post-process: atomic charges from TeraChem moldens via Multiwfn.
+# TeraChem GPU workers enqueue a molden as soon as it is valid; Multiwfn runs
+# concurrently and never occupies a GPU worker. Load a noGUI Multiwfn module in
+# the job script (e.g. module load multiwfn/v260410-noGui) alongside TeraChem.
+# Keep n_threads * n_processes within the node's CPU budget.
+Multiwfn:
+  enabled: false
+  executable: Multiwfn_noGUI
+  charge_method: 1.2cm5                             # hirshfeld, vdd, mulliken, lowdin, scpa, adch, cm5, 1.2cm5, mbis
+  n_threads: 12                                     # OpenMP threads per Multiwfn process (-nt / OMP_NUM_THREADS)
+  n_processes: 1                                    # concurrent Multiwfn jobs
+  # timeout: 3600                                   # seconds per structure; omit for no limit
+  keep_chg: true                                    # keep chrg-*/<index>.chg after merging Qa
+  # menu_inputs: ["7", "-16", "1", "y", "0", "q"]   # override stdin after the wavefunction is loaded
+  # settings_ini: /path/to/settings.ini
+  # pickle_fields may map Qa (e.g. Qa: chrg) for Enerzymette-style pickles
+

--- a/enerzyme/qm/multiwfn.py
+++ b/enerzyme/qm/multiwfn.py
@@ -138,12 +138,21 @@ def invoke_multiwfn(
     charge_method: str = "1.2cm5",
     menu_inputs: Optional[Sequence[str]] = None,
 ) -> Path:
-    """Run Multiwfn on one molden in ``workdir``; return the written ``.chg`` path."""
+    """Run Multiwfn on one molden in ``workdir``; return the written ``.chg`` path.
+
+    Clears any leftover ``*.chg`` in ``workdir`` before launching so a failed or
+    skipped Multiwfn run cannot reuse charges from a previous geometry.
+    """
     molden = Path(molden).resolve()
     if not molden.is_file() or molden.stat().st_size <= 0:
         raise FileNotFoundError(f"Invalid molden for Multiwfn: {molden}")
     workdir = Path(workdir)
     workdir.mkdir(parents=True, exist_ok=True)
+    for stale in workdir.glob("*.chg"):
+        try:
+            stale.unlink()
+        except OSError as e:
+            logger.warning(f"Could not remove stale workdir charge file {stale}: {e}")
     if settings_ini is not None:
         src = Path(settings_ini).expanduser().resolve()
         if not src.is_file():
@@ -157,9 +166,10 @@ def invoke_multiwfn(
     env = os.environ.copy()
     env["OMP_NUM_THREADS"] = str(n_threads)
     log_path = workdir / "multiwfn.log"
+    chg = workdir / f"{molden.stem}.chg"
     with open(log_path, "w") as log:
         try:
-            subprocess.run(
+            completed = subprocess.run(
                 cmd,
                 input=stdin,
                 stdout=log,
@@ -175,8 +185,12 @@ def invoke_multiwfn(
                 f"Multiwfn timed out after {timeout}s on {molden}"
             ) from e
 
-    chg = workdir / f"{molden.stem}.chg"
-    if not chg.is_file():
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Multiwfn exited with code {completed.returncode} on {molden}. "
+            f"See {log_path}"
+        )
+    if not chg.is_file() or chg.stat().st_size <= 0:
         raise FileNotFoundError(
             f"Multiwfn did not write {chg}. See {log_path}"
         )

--- a/enerzyme/qm/multiwfn.py
+++ b/enerzyme/qm/multiwfn.py
@@ -287,9 +287,20 @@ def _multiwfn_process_main(
             break
         index = int(job["index"])
         dest = chg_root / f"{index}.chg"
+        n_atoms = job.get("n_atoms")
         if dest.is_file() and dest.stat().st_size > 0:
-            logger.info(f"Multiwfn .chg for {index} already exists at {dest}; skipping")
-            continue
+            try:
+                parse_chg_file(dest, n_atoms=n_atoms)
+                logger.info(f"Multiwfn .chg for {index} already exists at {dest}; skipping")
+                continue
+            except Exception as e:
+                logger.warning(
+                    f"Corrupt Multiwfn .chg for {index} at {dest}: {e}; recomputing"
+                )
+                try:
+                    dest.unlink()
+                except OSError:
+                    pass
         workdir = tmp_root / str(index)
         try:
             chg = invoke_multiwfn(
@@ -302,7 +313,6 @@ def _multiwfn_process_main(
                 charge_method=str(config_dict["charge_method"]),
                 menu_inputs=config_dict.get("menu_inputs"),
             )
-            n_atoms = job.get("n_atoms")
             parse_chg_file(chg, n_atoms=n_atoms)
             if chg.resolve() != dest.resolve():
                 copy(chg, dest)

--- a/enerzyme/qm/multiwfn.py
+++ b/enerzyme/qm/multiwfn.py
@@ -1,0 +1,304 @@
+"""Multiwfn atomic-charge post-processing for ``enerzyme annotate``.
+
+TeraChem (GPU) writes a molden; a separate CPU process pool runs Multiwfn so
+charge jobs never occupy a TeraChem worker. Workers only write ``.chg`` files;
+the parent merges ``Qa`` into ASE LMDB / pickle after the pool joins.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import copy, which
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+import os
+import subprocess
+
+import numpy as np
+
+from ..utils import logger
+
+
+# Methods that ask "how to obtain atomic densities?" after the population option.
+# Answer ``1`` = built-in sphericalized atomic densities, then ``y`` to write .chg.
+_DENSITY_THEN_CHG: Dict[str, int] = {
+    "hirshfeld": 1,
+    "vdd": 2,
+    "adch": 11,
+    "cm5": 16,
+    "1.2cm5": -16,
+}
+
+# Löwdin asks for a population-print path before the .chg prompt (blank = screen).
+_LOWDIN_OPTION = 6
+
+# Mulliken has a nested submenu: ``1`` outputs charges, then ``y`` writes .chg,
+# then ``0`` leaves the submenu and ``0`` leaves the population menu.
+_MULLIKEN_OPTION = 5
+
+# SCPA writes .chg immediately after the option (no density prompt).
+_SCPA_OPTION = 7
+
+# MBIS: extra submenu ``1`` = start calculation, then ``y`` writes .chg.
+_MBIS_OPTION = 20
+
+CHARGE_METHODS: Dict[str, str] = {
+    "hirshfeld": "Hirshfeld atomic charge (menu 1)",
+    "vdd": "Voronoi deformation density (menu 2)",
+    "mulliken": "Mulliken (menu 5)",
+    "lowdin": "Löwdin (menu 6)",
+    "scpa": "Modified Mulliken / SCPA (menu 7)",
+    "adch": "ADCH (menu 11)",
+    "cm5": "CM5 (menu 16)",
+    "1.2cm5": "1.2×CM5 (menu -16)",
+    "mbis": "MBIS (menu 20)",
+}
+
+_SENTINEL = None
+
+
+def normalize_charge_method(name: str) -> str:
+    key = str(name).strip().lower().replace(" ", "").replace("_", "")
+    aliases = {
+        "1.2*cm5": "1.2cm5",
+        "12cm5": "1.2cm5",
+        "löwdin": "lowdin",
+        "hirschfeld": "hirshfeld",
+    }
+    return aliases.get(key, key)
+
+
+def build_multiwfn_stdin(
+    charge_method: str = "1.2cm5",
+    menu_inputs: Optional[Sequence[str]] = None,
+) -> str:
+    """Build Multiwfn stdin **after** the wavefunction is already loaded.
+
+    Pass the molden path as argv (``Multiwfn_noGUI molden -nt N``) so this string
+    starts at the main menu, not at the file-path prompt.
+    """
+    if menu_inputs:
+        lines = [str(x) for x in menu_inputs]
+        return "\n".join(lines) + "\n"
+
+    method = normalize_charge_method(charge_method)
+    if method in _DENSITY_THEN_CHG:
+        option = _DENSITY_THEN_CHG[method]
+        lines = ["7", str(option), "1", "y", "0", "q"]
+    elif method == "lowdin":
+        lines = ["7", str(_LOWDIN_OPTION), "", "y", "0", "q"]
+    elif method == "mulliken":
+        lines = ["7", str(_MULLIKEN_OPTION), "1", "y", "0", "0", "q"]
+    elif method == "scpa":
+        lines = ["7", str(_SCPA_OPTION), "y", "0", "q"]
+    elif method == "mbis":
+        lines = ["7", str(_MBIS_OPTION), "1", "y", "0", "q"]
+    else:
+        known = ", ".join(sorted(CHARGE_METHODS))
+        raise ValueError(
+            f"Unknown Multiwfn charge_method {charge_method!r}. "
+            f"Known methods: {known}. Or pass menu_inputs for a custom recipe "
+            "(Hirshfeld-I / RESP / CHELPG / AIM need extra prompts)."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_chg_file(chg_path: Path, n_atoms: Optional[int] = None) -> np.ndarray:
+    """Read Multiwfn ``.chg`` column 5 (atomic charge)."""
+    path = Path(chg_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Multiwfn .chg not found: {path}")
+    qa = np.loadtxt(path, usecols=4, ndmin=1, dtype=float)
+    if n_atoms is not None and qa.size != int(n_atoms):
+        raise ValueError(
+            f"{path} has {qa.size} charges but structure has {n_atoms} atoms"
+        )
+    return qa
+
+
+def resolve_multiwfn_executable(executable: str) -> str:
+    path = Path(executable).expanduser()
+    if path.is_file():
+        return str(path.resolve())
+    found = which(executable)
+    if found:
+        return found
+    raise FileNotFoundError(
+        f"Multiwfn executable {executable!r} not found on PATH. "
+        "Load a noGUI module (e.g. multiwfn/v260410-noGui) in the job script."
+    )
+
+
+def invoke_multiwfn(
+    molden: Path,
+    workdir: Path,
+    n_threads: int,
+    executable: str = "Multiwfn_noGUI",
+    timeout: Optional[float] = None,
+    settings_ini: Optional[Path] = None,
+    charge_method: str = "1.2cm5",
+    menu_inputs: Optional[Sequence[str]] = None,
+) -> Path:
+    """Run Multiwfn on one molden in ``workdir``; return the written ``.chg`` path."""
+    molden = Path(molden).resolve()
+    if not molden.is_file() or molden.stat().st_size <= 0:
+        raise FileNotFoundError(f"Invalid molden for Multiwfn: {molden}")
+    workdir = Path(workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    if settings_ini is not None:
+        src = Path(settings_ini).expanduser().resolve()
+        if not src.is_file():
+            raise FileNotFoundError(f"Multiwfn settings_ini not found: {src}")
+        copy(src, workdir / "settings.ini")
+
+    exe = resolve_multiwfn_executable(executable)
+    n_threads = max(1, int(n_threads))
+    cmd = [exe, str(molden), "-nt", str(n_threads)]
+    stdin = build_multiwfn_stdin(charge_method=charge_method, menu_inputs=menu_inputs)
+    env = os.environ.copy()
+    env["OMP_NUM_THREADS"] = str(n_threads)
+    log_path = workdir / "multiwfn.log"
+    with open(log_path, "w") as log:
+        try:
+            subprocess.run(
+                cmd,
+                input=stdin,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                timeout=timeout,
+                check=False,
+                cwd=str(workdir),
+                env=env,
+                text=True,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise TimeoutError(
+                f"Multiwfn timed out after {timeout}s on {molden}"
+            ) from e
+
+    chg = workdir / f"{molden.stem}.chg"
+    if not chg.is_file():
+        raise FileNotFoundError(
+            f"Multiwfn did not write {chg}. See {log_path}"
+        )
+    return chg
+
+
+@dataclass
+class MultiwfnConfig:
+    enabled: bool = False
+    executable: str = "Multiwfn_noGUI"
+    charge_method: str = "1.2cm5"
+    n_threads: int = 12
+    n_processes: int = 1
+    timeout: Optional[float] = None
+    keep_chg: bool = True
+    keep_molden: bool = False
+    menu_inputs: Optional[List[str]] = None
+    settings_ini: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "executable": self.executable,
+            "charge_method": self.charge_method,
+            "n_threads": int(self.n_threads),
+            "n_processes": int(self.n_processes),
+            "timeout": self.timeout,
+            "keep_chg": bool(self.keep_chg),
+            "keep_molden": bool(self.keep_molden),
+            "menu_inputs": list(self.menu_inputs) if self.menu_inputs else None,
+            "settings_ini": self.settings_ini,
+        }
+
+
+def parse_multiwfn_config(
+    raw: Optional[Mapping[str, Any]],
+    *,
+    keep_molden: bool = False,
+) -> MultiwfnConfig:
+    if not raw:
+        return MultiwfnConfig(enabled=False, keep_molden=keep_molden)
+    data = dict(raw)
+    enabled = bool(data.get("enabled", True))
+    menu_inputs = data.get("menu_inputs")
+    if menu_inputs is not None:
+        menu_inputs = [str(x) for x in menu_inputs]
+    n_proc = int(data.get("n_processes", 1) or 1)
+    n_threads = int(data.get("n_threads", 12) or 1)
+    timeout = data.get("timeout", None)
+    if timeout is not None:
+        timeout = float(timeout)
+    method = str(data.get("charge_method", "1.2cm5"))
+    cfg = MultiwfnConfig(
+        enabled=enabled,
+        executable=str(data.get("executable", "Multiwfn_noGUI")),
+        charge_method=method,
+        n_threads=max(1, n_threads),
+        n_processes=max(1, n_proc),
+        timeout=timeout,
+        keep_chg=bool(data.get("keep_chg", True)),
+        keep_molden=keep_molden,
+        menu_inputs=menu_inputs,
+        settings_ini=data.get("settings_ini"),
+    )
+    if cfg.enabled and not menu_inputs:
+        # Validate method early so annotate fails before QC, not mid-queue.
+        build_multiwfn_stdin(charge_method=cfg.charge_method)
+    return cfg
+
+
+def chg_dirname(charge_method: str) -> str:
+    method = normalize_charge_method(charge_method)
+    if method == "1.2cm5":
+        return "chrg-12CM5"
+    return f"chrg-{method}"
+
+
+def _multiwfn_process_main(
+    job_queue,
+    config_dict: Dict[str, Any],
+    chg_dir: str,
+    tmp_base: str,
+) -> None:
+    """Long-lived Multiwfn worker: pull jobs until a sentinel (``None``)."""
+    chg_root = Path(chg_dir)
+    chg_root.mkdir(parents=True, exist_ok=True)
+    tmp_root = Path(tmp_base)
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    settings = config_dict.get("settings_ini")
+    settings_path = Path(settings) if settings else None
+    while True:
+        job = job_queue.get()
+        if job is _SENTINEL:
+            break
+        index = int(job["index"])
+        dest = chg_root / f"{index}.chg"
+        if dest.is_file() and dest.stat().st_size > 0:
+            logger.info(f"Multiwfn .chg for {index} already exists at {dest}; skipping")
+            continue
+        workdir = tmp_root / str(index)
+        try:
+            chg = invoke_multiwfn(
+                molden=Path(job["molden"]),
+                workdir=workdir,
+                n_threads=int(config_dict["n_threads"]),
+                executable=str(config_dict["executable"]),
+                timeout=config_dict.get("timeout"),
+                settings_ini=settings_path,
+                charge_method=str(config_dict["charge_method"]),
+                menu_inputs=config_dict.get("menu_inputs"),
+            )
+            n_atoms = job.get("n_atoms")
+            parse_chg_file(chg, n_atoms=n_atoms)
+            if chg.resolve() != dest.resolve():
+                copy(chg, dest)
+            logger.info(f"Multiwfn charges written: {dest}")
+            if not config_dict.get("keep_molden"):
+                molden = Path(job["molden"])
+                try:
+                    if molden.is_file():
+                        molden.unlink()
+                except OSError as e:
+                    logger.warning(f"Could not delete staged molden {molden}: {e}")
+        except Exception as e:
+            logger.warning(f"Multiwfn failed for structure {index}: {e}")

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -447,6 +447,7 @@ class QMDriver(ABC):
         # Prefer a parent-assigned id (multiprocess); otherwise claim by structure index.
         # Bare reserve() is wrong: with no key-value pairs ASE treats any existing row as a
         # hit and returns None after the first insert.
+        preserve_on_failure = bool(atoms.info.pop("aselmdb_preserve_on_failure", False))
         if "aselmdb_row_id" in atoms.info:
             system_id = atoms.info["aselmdb_row_id"]
             if system_id is None:
@@ -456,8 +457,9 @@ class QMDriver(ABC):
             if system_id is None:
                 return
 
-        # Always release the reservation unless the row is successfully written;
-        # otherwise orphaned reserved rows block later runs of the same index.
+        # Release fresh reservations on failure so orphaned reserved rows do not
+        # block later runs. When overwriting a previously complete energy row
+        # (Multiwfn molden-missing resume), keep that row if the rerun fails.
         wrote = False
         try:
             result_package = self._run_qm(atoms)
@@ -481,7 +483,7 @@ class QMDriver(ABC):
                 f"Failed to store ASE LMDB row for structure {index} (id={system_id}): {e}"
             )
         finally:
-            if not wrote:
+            if not wrote and not preserve_on_failure:
                 try:
                     db.delete([system_id])
                 except Exception as e:
@@ -489,6 +491,11 @@ class QMDriver(ABC):
                         f"Could not delete reserved ASE LMDB id {system_id} "
                         f"for structure {index}: {e}"
                     )
+            elif not wrote and preserve_on_failure:
+                logger.warning(
+                    f"Keeping existing ASE LMDB row id={system_id} for structure {index} "
+                    "after failed TeraChem rerun"
+                )
 
     def single_run_pickle(self, atoms: Atoms) -> Optional[Dict[str, Any]]:
         index = int(atoms.info["index"])
@@ -887,6 +894,7 @@ class QMDriver(ABC):
                     "re-running TeraChem"
                 )
                 atoms.info["aselmdb_row_id"] = complete[0].id
+                atoms.info["aselmdb_preserve_on_failure"] = True
                 to_qm.append(atoms)
         return to_qm, to_mw
 

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -495,7 +495,7 @@ class QMDriver(ABC):
         cached = self.load_pickle_single_run(index)
         if cached is not None:
             if self.multiwfn.enabled and not self._datapoint_has_qa(cached):
-                if self._chg_is_ready(index):
+                if self._chg_is_ready(index, n_atoms=len(atoms)):
                     # Charges already on disk (crash between Multiwfn and pickle merge).
                     # Keep the cached TeraChem result; parent merge will attach Qa.
                     return cached
@@ -643,9 +643,24 @@ class QMDriver(ABC):
     def _chg_path(self, index: int) -> Path:
         return self.chg_dir / f"{int(index)}.chg"
 
-    def _chg_is_ready(self, index: int) -> bool:
+    def _chg_is_ready(self, index: int, n_atoms: Optional[int] = None) -> bool:
+        """True when ``chrg-*/<index>.chg`` exists and parses as atomic charges.
+
+        Corrupt / truncated files are deleted so a later resume can re-enqueue
+        Multiwfn (or TeraChem) instead of permanently skipping charge recovery.
+        """
         path = self._chg_path(index)
-        return path.is_file() and path.stat().st_size > 0
+        if not path.is_file() or path.stat().st_size <= 0:
+            return False
+        try:
+            parse_chg_file(path, n_atoms=n_atoms)
+        except Exception as e:
+            logger.warning(
+                f"Corrupt Multiwfn charge file for {index} ({path}): {e}; removing"
+            )
+            self._clear_chg(index)
+            return False
+        return True
 
     def _molden_path(self, index: int) -> Path:
         return self.molden_dir / f"{int(index)}.molden"
@@ -685,7 +700,7 @@ class QMDriver(ABC):
     def _enqueue_multiwfn(self, index: int, molden: Path, n_atoms: int) -> None:
         if not self.multiwfn.enabled:
             return
-        if self._chg_is_ready(index):
+        if self._chg_is_ready(index, n_atoms=n_atoms):
             return
         job = {
             "index": int(index),
@@ -780,6 +795,7 @@ class QMDriver(ABC):
                 qa = parse_chg_file(path, n_atoms=n_atoms)
             except Exception as e:
                 logger.warning(f"Could not parse Multiwfn charges for {index}: {e}")
+                self._clear_chg(index)
                 continue
             self._set_qa_on_datapoint(datapoint, qa)
             if self.dump_single_run:
@@ -811,6 +827,7 @@ class QMDriver(ABC):
                 qa = parse_chg_file(path, n_atoms=len(atoms))
             except Exception as e:
                 logger.warning(f"Could not parse Multiwfn charges for {index}: {e}")
+                self._clear_chg(int(index))
                 continue
             results = dict(getattr(atoms.calc, "results", {}) or {})
             results["charges"] = qa
@@ -850,7 +867,9 @@ class QMDriver(ABC):
                     f"System {index} already completed in {self.output_path}. Skipping..."
                 )
                 continue
-            if any(_aselmdb_row_has_charges(row) for row in complete) or self._chg_is_ready(index):
+            if any(_aselmdb_row_has_charges(row) for row in complete) or self._chg_is_ready(
+                index, n_atoms=len(atoms)
+            ):
                 logger.info(
                     f"System {index} already completed with charges. Skipping..."
                 )

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -423,6 +423,7 @@ class QMDriver(ABC):
                 molden_src if self.keep_molden else None,
             )
             if self.multiwfn.enabled:
+                self._clear_chg(index)
                 staged = self._stage_molden(index, molden_src)
                 if staged is not None:
                     result_package["molden_file"] = staged
@@ -649,12 +650,23 @@ class QMDriver(ABC):
     def _molden_path(self, index: int) -> Path:
         return self.molden_dir / f"{int(index)}.molden"
 
+    def _clear_chg(self, index: int) -> None:
+        """Remove a stale ``.chg`` after a fresh TeraChem run for this index."""
+        path = self._chg_path(index)
+        if not path.is_file():
+            return
+        try:
+            path.unlink()
+            logger.info(f"Removed stale Multiwfn charge file {path}")
+        except OSError as e:
+            logger.warning(f"Could not remove stale charge file {path}: {e}")
+
     def _stage_molden(self, index: int, molden_src: Optional[Path]) -> Optional[Path]:
         """Copy a TeraChem molden to the persistent moldens/ dir if it is valid."""
         dest = self._molden_path(index)
-        if dest.is_file() and dest.stat().st_size > 0:
-            return dest
         if molden_src is None:
+            if dest.is_file() and dest.stat().st_size > 0:
+                return dest
             return None
         src = Path(molden_src)
         if not src.is_file() or src.stat().st_size <= 0:

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -651,15 +651,21 @@ class QMDriver(ABC):
         return self.molden_dir / f"{int(index)}.molden"
 
     def _clear_chg(self, index: int) -> None:
-        """Remove a stale ``.chg`` after a fresh TeraChem run for this index."""
+        """Remove stale charge files after a fresh TeraChem run for this index."""
         path = self._chg_path(index)
-        if not path.is_file():
-            return
-        try:
-            path.unlink()
-            logger.info(f"Removed stale Multiwfn charge file {path}")
-        except OSError as e:
-            logger.warning(f"Could not remove stale charge file {path}: {e}")
+        if path.is_file():
+            try:
+                path.unlink()
+                logger.info(f"Removed stale Multiwfn charge file {path}")
+            except OSError as e:
+                logger.warning(f"Could not remove stale charge file {path}: {e}")
+        workdir = self.output_dir / "multiwfn_tmp" / str(int(index))
+        if workdir.is_dir():
+            for stale in workdir.glob("*.chg"):
+                try:
+                    stale.unlink()
+                except OSError as e:
+                    logger.warning(f"Could not remove stale workdir charge file {stale}: {e}")
 
     def _stage_molden(self, index: int, molden_src: Optional[Path]) -> Optional[Path]:
         """Copy a TeraChem molden to the persistent moldens/ dir if it is valid."""

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -422,16 +422,15 @@ class QMDriver(ABC):
                 output_file,
                 molden_src if self.keep_molden else None,
             )
-            staged = self._stage_molden(index, molden_src)
-            if staged is not None:
-                result_package["molden_file"] = staged
             if self.multiwfn.enabled:
-                if staged is None:
+                staged = self._stage_molden(index, molden_src)
+                if staged is not None:
+                    result_package["molden_file"] = staged
+                    self._enqueue_multiwfn(index, staged, n_atoms=len(atoms))
+                else:
                     logger.warning(
                         f"No valid molden for structure {index}; skipping Multiwfn"
                     )
-                else:
-                    self._enqueue_multiwfn(index, staged, n_atoms=len(atoms))
         except Exception as e:
             logger.warning(f"Calculation of structure {index} failed: {e}")
             if self.clean_tmp and tmp_dir.exists():
@@ -495,6 +494,10 @@ class QMDriver(ABC):
         cached = self.load_pickle_single_run(index)
         if cached is not None:
             if self.multiwfn.enabled and not self._datapoint_has_qa(cached):
+                if self._chg_is_ready(index):
+                    # Charges already on disk (crash between Multiwfn and pickle merge).
+                    # Keep the cached TeraChem result; parent merge will attach Qa.
+                    return cached
                 molden = self._molden_path(index)
                 if molden.is_file() and molden.stat().st_size > 0:
                     self._enqueue_multiwfn_from_existing_molden(index, n_atoms=len(atoms))
@@ -639,6 +642,10 @@ class QMDriver(ABC):
     def _chg_path(self, index: int) -> Path:
         return self.chg_dir / f"{int(index)}.chg"
 
+    def _chg_is_ready(self, index: int) -> bool:
+        path = self._chg_path(index)
+        return path.is_file() and path.stat().st_size > 0
+
     def _molden_path(self, index: int) -> Path:
         return self.molden_dir / f"{int(index)}.molden"
 
@@ -660,7 +667,7 @@ class QMDriver(ABC):
     def _enqueue_multiwfn(self, index: int, molden: Path, n_atoms: int) -> None:
         if not self.multiwfn.enabled:
             return
-        if self._chg_path(index).is_file() and self._chg_path(index).stat().st_size > 0:
+        if self._chg_is_ready(index):
             return
         job = {
             "index": int(index),
@@ -825,10 +832,7 @@ class QMDriver(ABC):
                     f"System {index} already completed in {self.output_path}. Skipping..."
                 )
                 continue
-            has_chg = (
-                self._chg_path(index).is_file() and self._chg_path(index).stat().st_size > 0
-            )
-            if any(_aselmdb_row_has_charges(row) for row in complete) or has_chg:
+            if any(_aselmdb_row_has_charges(row) for row in complete) or self._chg_is_ready(index):
                 logger.info(
                     f"System {index} already completed with charges. Skipping..."
                 )

--- a/enerzyme/qm/qm_driver.py
+++ b/enerzyme/qm/qm_driver.py
@@ -3,7 +3,7 @@ from shutil import copy, rmtree
 import os
 import subprocess
 from pickle import dump, load
-from typing import Any, Dict, Literal, Optional, List
+from typing import Any, Dict, Literal, Optional, List, Mapping
 from pathlib import Path
 from abc import ABC, abstractmethod
 import ase.io
@@ -13,9 +13,26 @@ from ase import Atoms
 from ase.db import connect
 from ase.calculators.singlepoint import SinglePointCalculator
 from tqdm import tqdm
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool, Process, Queue, cpu_count
 from ..utils import logger
 from ..data.supplier import Supplier
+from .multiwfn import (
+    MultiwfnConfig,
+    chg_dirname,
+    parse_chg_file,
+    parse_multiwfn_config,
+    resolve_multiwfn_executable,
+    _multiwfn_process_main,
+)
+
+
+# Injected into TeraChem Pool workers so they share the parent's Multiwfn job queue.
+_MW_JOB_QUEUE = None
+
+
+def _init_mw_job_queue(queue) -> None:
+    global _MW_JOB_QUEUE
+    _MW_JOB_QUEUE = queue
 
 
 QM_CALCULATED_TO_ASE_PROPERTY = {
@@ -122,6 +139,21 @@ def _aselmdb_row_is_complete(row) -> bool:
     return energy is not None
 
 
+def _aselmdb_row_has_charges(row) -> bool:
+    """True when a completed ASE DB row already stores calculator charges."""
+    try:
+        atoms = row.toatoms()
+    except Exception:
+        return False
+    if atoms.calc is None:
+        return False
+    try:
+        charges = atoms.calc.results.get("charges", None)
+    except Exception:
+        return False
+    return charges is not None
+
+
 def _build_standard_pickle_datapoint(
     atoms: Atoms,
     result_package: Dict[str, Any],
@@ -129,7 +161,7 @@ def _build_standard_pickle_datapoint(
     """Driver results (E/Fa in eV) → standard Enerzyme pickle fields (E/Fa in Ha / Ha·Å⁻¹)."""
     energy_ev = float(result_package["E"])
     forces_ev = np.asarray(result_package["Fa"], dtype=float)
-    return {
+    datapoint = {
         "E": energy_ev / Ha,
         "Fa": forces_ev / Ha,
         "M2": np.asarray(result_package.get("M2", np.zeros(3)), dtype=float),
@@ -140,6 +172,9 @@ def _build_standard_pickle_datapoint(
         "S": int(atoms.info.get("spin", 1)) - 1,
         "index": int(atoms.info["index"]),
     }
+    if "Qa" in result_package:
+        datapoint["Qa"] = np.asarray(result_package["Qa"], dtype=float)
+    return datapoint
 
 
 def _apply_pickle_fields(
@@ -195,6 +230,7 @@ class QMDriver(ABC):
         n_processes: int = 1,
         timeout: Optional[float] = None,
         dump_single_run: bool = True,
+        multiwfn_config: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ):
         '''
@@ -226,14 +262,26 @@ class QMDriver(ABC):
         os.makedirs(self.output_dir, exist_ok=True)
         self.template_input_file = template_input_file
         self.keep_molden = keep_molden
-        if keep_molden:
-            os.makedirs(self.output_dir / "moldens", exist_ok=True)
         self.keep_stdout = _resolve_keep_stdout(keep_stdout, kwargs)
         if self.keep_stdout:
             os.makedirs(self.output_dir / "stdout", exist_ok=True)
         self.clean_tmp = clean_tmp
         self.n_processes = n_processes if n_processes > 0 else cpu_count()
         self.timeout = timeout
+        self.multiwfn = parse_multiwfn_config(multiwfn_config, keep_molden=keep_molden)
+        self._mw_job_queue = None
+        self._mw_procs: List[Process] = []
+        self._mw_pool_started = False
+        if self.keep_molden or self.multiwfn.enabled:
+            os.makedirs(self.output_dir / "moldens", exist_ok=True)
+        if self.multiwfn.enabled:
+            os.makedirs(self.chg_dir, exist_ok=True)
+            logger.info(
+                f"Multiwfn charges enabled: method={self.multiwfn.charge_method}, "
+                f"n_threads={self.multiwfn.n_threads}, "
+                f"n_processes={self.multiwfn.n_processes}, "
+                f"chg_dir={self.chg_dir}"
+            )
         if self.output_format == "pickle" and self.dump_single_run:
             os.makedirs(self.single_run_dir, exist_ok=True)
         elif self.output_format == "aselmdb" and not self.dump_single_run:
@@ -251,6 +299,14 @@ class QMDriver(ABC):
     @property
     def single_run_dir(self) -> Path:
         return self.output_dir / "single_run"
+
+    @property
+    def chg_dir(self) -> Path:
+        return self.output_dir / chg_dirname(self.multiwfn.charge_method)
+
+    @property
+    def molden_dir(self) -> Path:
+        return self.output_dir / "moldens"
 
     @abstractmethod
     def make_input(self, atoms: Atoms, tmp_dir: Path) -> None:
@@ -299,8 +355,11 @@ class QMDriver(ABC):
 
     def aselmdb_schema_properties(self) -> List[str]:
         """Standard names written into ASE LMDB metadata for Datahub discovery."""
-        # Geometry/charge always; E/Fa/M2 from successful QM (Qa/Sa only if a driver adds them).
-        return list(_ASELMDB_SCHEMA_GEOMETRY) + ["E", "Fa", "M2"]
+        # Geometry/charge always; E/Fa/M2 from successful QM (Qa when Multiwfn is enabled).
+        props = list(_ASELMDB_SCHEMA_GEOMETRY) + ["E", "Fa", "M2"]
+        if self.multiwfn.enabled:
+            props.append("Qa")
+        return props
 
     def _ensure_aselmdb_schema(self) -> None:
         """Persist property schema so readers need not rely on the first row alone."""
@@ -358,7 +417,21 @@ class QMDriver(ABC):
             input_file = self.make_input(atoms, tmp_dir)
             output_file = self.invoke_qm(input_file, atoms, tmp_dir)
             result_package = self.collect_results(input_file, atoms, tmp_dir)
-            self.copy_files(output_file, result_package.get("molden_file", None))
+            molden_src = result_package.get("molden_file", None)
+            self.copy_files(
+                output_file,
+                molden_src if self.keep_molden else None,
+            )
+            staged = self._stage_molden(index, molden_src)
+            if staged is not None:
+                result_package["molden_file"] = staged
+            if self.multiwfn.enabled:
+                if staged is None:
+                    logger.warning(
+                        f"No valid molden for structure {index}; skipping Multiwfn"
+                    )
+                else:
+                    self._enqueue_multiwfn(index, staged, n_atoms=len(atoms))
         except Exception as e:
             logger.warning(f"Calculation of structure {index} failed: {e}")
             if self.clean_tmp and tmp_dir.exists():
@@ -421,7 +494,17 @@ class QMDriver(ABC):
         index = int(atoms.info["index"])
         cached = self.load_pickle_single_run(index)
         if cached is not None:
-            return cached
+            if self.multiwfn.enabled and not self._datapoint_has_qa(cached):
+                molden = self._molden_path(index)
+                if molden.is_file() and molden.stat().st_size > 0:
+                    self._enqueue_multiwfn_from_existing_molden(index, n_atoms=len(atoms))
+                    return cached
+                logger.warning(
+                    f"Structure {index} is missing Multiwfn charges and molden; "
+                    "re-running TeraChem"
+                )
+            else:
+                return cached
         result_package = self._run_qm(atoms)
         if result_package is None:
             return None
@@ -438,10 +521,15 @@ class QMDriver(ABC):
         return self.single_run_aselmdb(atoms)
 
     def run(self):
-        if self.output_format == "pickle":
-            self._run_pickle()
-        else:
-            self._run_aselmdb()
+        try:
+            if self.multiwfn.enabled:
+                self._start_multiwfn_pool()
+            if self.output_format == "pickle":
+                self._run_pickle()
+            else:
+                self._run_aselmdb()
+        finally:
+            self._stop_multiwfn_pool()
 
     def _reserve_aselmdb_ids(self, atoms_list: List[Atoms]) -> List[Atoms]:
         """Serially claim unique ASE row ids keyed by structure ``index``.
@@ -455,6 +543,9 @@ class QMDriver(ABC):
         db = connect(self.output_path, **self.default_connect_args)
         to_run: List[Atoms] = []
         for atoms in atoms_list:
+            if atoms.info.get("aselmdb_row_id") is not None:
+                to_run.append(atoms)
+                continue
             index = int(atoms.info["index"])
             system_id = self._claim_aselmdb_row_id(db, index)
             if system_id is None:
@@ -470,9 +561,20 @@ class QMDriver(ABC):
         ``SDMolSupplier``) in the pickled driver fails for SDF inputs.
         """
         supplier = self.supplier
+        mw_queue = self._mw_job_queue
+        mw_procs = self._mw_procs
         self.supplier = None
+        # Pool pickles the bound worker (and thus ``self``). Drop the job queue
+        # so workers receive it only via initializer (avoids Manager auth errors).
+        self._mw_job_queue = None
+        self._mw_procs = []
+        initializer = None
+        initargs = ()
+        if self.multiwfn.enabled and mw_queue is not None:
+            initializer = _init_mw_job_queue
+            initargs = (mw_queue,)
         try:
-            with Pool(self.n_processes) as p:
+            with Pool(self.n_processes, initializer=initializer, initargs=initargs) as p:
                 return list(tqdm(
                     p.imap(worker, items),
                     desc="Running QM",
@@ -483,20 +585,33 @@ class QMDriver(ABC):
                 ))
         finally:
             self.supplier = supplier
+            self._mw_job_queue = mw_queue
+            self._mw_procs = mw_procs
 
     def _run_aselmdb(self) -> None:
         self._ensure_aselmdb_schema()
-        if self.n_processes == 1:
-            for atoms in tqdm(self.supplier.suppl(), desc="Running QM", dynamic_ncols=True, leave=False, position=0):
+        atoms_list = list(self.supplier.suppl())
+        to_qm, to_mw_only = self._partition_aselmdb_work(atoms_list)
+        for atoms in to_mw_only:
+            self._enqueue_multiwfn_from_existing_molden(
+                int(atoms.info["index"]), n_atoms=len(atoms)
+            )
+        if not to_qm:
+            pass
+        elif self.n_processes == 1:
+            for atoms in tqdm(to_qm, desc="Running QM", dynamic_ncols=True, leave=False, position=0):
                 self.single_run_aselmdb(atoms)
         else:
             logger.info(f"Running QM calculations with {self.n_processes} processes")
-            atoms_list = self._reserve_aselmdb_ids(list(self.supplier.suppl()))
+            reserved = self._reserve_aselmdb_ids(to_qm)
             self._pool_imap(
                 self.single_run_aselmdb,
-                atoms_list,
-                total=len(atoms_list),
+                reserved,
+                total=len(reserved),
             )
+        self._stop_multiwfn_pool()
+        if self.multiwfn.enabled:
+            self._merge_qa_aselmdb()
         logger.info(f"QM calculations finished. ASE LMDB saved to {self.output_path}")
 
     def _run_pickle(self) -> None:
@@ -514,9 +629,225 @@ class QMDriver(ABC):
                 total=len(atoms_list),
             )
         datapoints = [r for r in result_packages if r]
+        self._stop_multiwfn_pool()
+        if self.multiwfn.enabled:
+            self._merge_qa_pickle(datapoints)
         with open(self.output_path, "wb") as f:
             dump(datapoints, f)
         logger.info(f"QM calculations finished. Pickle saved to {self.output_path} ({len(datapoints)} structures)")
+
+    def _chg_path(self, index: int) -> Path:
+        return self.chg_dir / f"{int(index)}.chg"
+
+    def _molden_path(self, index: int) -> Path:
+        return self.molden_dir / f"{int(index)}.molden"
+
+    def _stage_molden(self, index: int, molden_src: Optional[Path]) -> Optional[Path]:
+        """Copy a TeraChem molden to the persistent moldens/ dir if it is valid."""
+        dest = self._molden_path(index)
+        if dest.is_file() and dest.stat().st_size > 0:
+            return dest
+        if molden_src is None:
+            return None
+        src = Path(molden_src)
+        if not src.is_file() or src.stat().st_size <= 0:
+            return None
+        os.makedirs(dest.parent, exist_ok=True)
+        if src.resolve() != dest.resolve():
+            copy(src, dest)
+        return dest
+
+    def _enqueue_multiwfn(self, index: int, molden: Path, n_atoms: int) -> None:
+        if not self.multiwfn.enabled:
+            return
+        if self._chg_path(index).is_file() and self._chg_path(index).stat().st_size > 0:
+            return
+        job = {
+            "index": int(index),
+            "molden": str(Path(molden).resolve()),
+            "n_atoms": int(n_atoms),
+        }
+        queue = _MW_JOB_QUEUE if _MW_JOB_QUEUE is not None else self._mw_job_queue
+        if queue is None:
+            logger.warning(
+                f"Multiwfn job queue is not running; cannot enqueue structure {index}"
+            )
+            return
+        queue.put(job)
+
+    def _enqueue_multiwfn_from_existing_molden(self, index: int, n_atoms: int) -> None:
+        staged = self._stage_molden(index, None)
+        if staged is None:
+            logger.warning(
+                f"Structure {index} needs Multiwfn charges but {self._molden_path(index)} "
+                "is missing; re-run TeraChem with a template that writes molden."
+            )
+            return
+        self._enqueue_multiwfn(index, staged, n_atoms=n_atoms)
+
+    def _start_multiwfn_pool(self) -> None:
+        if self._mw_pool_started or not self.multiwfn.enabled:
+            return
+        resolve_multiwfn_executable(self.multiwfn.executable)
+        self._mw_job_queue = Queue()
+        cfg = self.multiwfn.to_dict()
+        tmp_base = str(self.output_dir / "multiwfn_tmp")
+        self._mw_procs = []
+        for _ in range(self.multiwfn.n_processes):
+            proc = Process(
+                target=_multiwfn_process_main,
+                args=(self._mw_job_queue, cfg, str(self.chg_dir), tmp_base),
+            )
+            proc.start()
+            self._mw_procs.append(proc)
+        self._mw_pool_started = True
+        logger.info(
+            f"Started {len(self._mw_procs)} Multiwfn worker(s) "
+            f"({self.multiwfn.n_threads} threads each)"
+        )
+
+    def _stop_multiwfn_pool(self) -> None:
+        if not self._mw_pool_started:
+            return
+        n = len(self._mw_procs)
+        if self._mw_job_queue is not None:
+            for _ in range(n):
+                self._mw_job_queue.put(None)
+        for proc in self._mw_procs:
+            proc.join()
+            if proc.exitcode not in (0, None):
+                logger.warning(
+                    f"Multiwfn worker pid={proc.pid} exited with code {proc.exitcode}"
+                )
+        self._mw_procs = []
+        self._mw_job_queue = None
+        self._mw_pool_started = False
+        logger.info("Multiwfn workers finished")
+
+    def _qa_pickle_key(self) -> str:
+        if not self.pickle_fields:
+            return "Qa"
+        if "Qa" in self.pickle_fields:
+            custom = self.pickle_fields["Qa"]
+            return "Qa" if custom is None else str(custom)
+        return "Qa"
+
+    def _datapoint_has_qa(self, datapoint: Dict[str, Any]) -> bool:
+        keys = {"Qa", "chrg", self._qa_pickle_key()}
+        return any(datapoint.get(key) is not None for key in keys)
+
+    def _set_qa_on_datapoint(self, datapoint: Dict[str, Any], qa: np.ndarray) -> None:
+        if self.pickle_fields and "Qa" not in self.pickle_fields:
+            logger.warning(
+                "Multiwfn Qa is present but pickle_fields has no Qa mapping; storing as 'Qa'"
+            )
+        datapoint[self._qa_pickle_key()] = qa
+
+    def _merge_qa_pickle(self, datapoints: List[Dict[str, Any]]) -> None:
+        n_ok = 0
+        for datapoint in datapoints:
+            index = int(datapoint["index"])
+            path = self._chg_path(index)
+            if not path.is_file():
+                continue
+            try:
+                n_atoms = datapoint.get("N")
+                qa = parse_chg_file(path, n_atoms=n_atoms)
+            except Exception as e:
+                logger.warning(f"Could not parse Multiwfn charges for {index}: {e}")
+                continue
+            self._set_qa_on_datapoint(datapoint, qa)
+            if self.dump_single_run:
+                self.dump_pickle_single_run(datapoint)
+            n_ok += 1
+            if not self.multiwfn.keep_chg:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+        logger.info(f"Merged Multiwfn Qa into {n_ok}/{len(datapoints)} pickle datapoints")
+
+    def _merge_qa_aselmdb(self) -> None:
+        if not self.output_path.exists():
+            return
+        db = connect(self.output_path, **self.default_connect_args)
+        n_ok = 0
+        n_rows = 0
+        for row in db.select():
+            n_rows += 1
+            index = row.get("index")
+            if index is None:
+                continue
+            path = self._chg_path(int(index))
+            if not path.is_file():
+                continue
+            try:
+                atoms = row.toatoms()
+                qa = parse_chg_file(path, n_atoms=len(atoms))
+            except Exception as e:
+                logger.warning(f"Could not parse Multiwfn charges for {index}: {e}")
+                continue
+            results = dict(getattr(atoms.calc, "results", {}) or {})
+            results["charges"] = qa
+            atoms.calc = SinglePointCalculator(atoms=atoms, **results)
+            data = dict(row.data or {})
+            data.setdefault("charge", atoms.info.get("charge", 0))
+            data.setdefault("spin", atoms.info.get("spin", 1))
+            data.setdefault("index", int(index))
+            db.write(atoms, id=row.id, data=data, index=int(index))
+            n_ok += 1
+            if not self.multiwfn.keep_chg:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+        self._ensure_aselmdb_schema()
+        logger.info(f"Merged Multiwfn Qa into {n_ok}/{n_rows} ASE LMDB rows")
+
+    def _partition_aselmdb_work(
+        self, atoms_list: List[Atoms]
+    ) -> tuple[List[Atoms], List[Atoms]]:
+        """Split structures into TeraChem work vs Multiwfn-only resume."""
+        if not self.output_path.exists():
+            return list(atoms_list), []
+        db = connect(self.output_path, **self.default_connect_args)
+        to_qm: List[Atoms] = []
+        to_mw: List[Atoms] = []
+        for atoms in atoms_list:
+            index = int(atoms.info["index"])
+            existing = list(db.select(index=index))
+            complete = [row for row in existing if _aselmdb_row_is_complete(row)]
+            if not complete:
+                to_qm.append(atoms)
+                continue
+            if not self.multiwfn.enabled:
+                logger.info(
+                    f"System {index} already completed in {self.output_path}. Skipping..."
+                )
+                continue
+            has_chg = (
+                self._chg_path(index).is_file() and self._chg_path(index).stat().st_size > 0
+            )
+            if any(_aselmdb_row_has_charges(row) for row in complete) or has_chg:
+                logger.info(
+                    f"System {index} already completed with charges. Skipping..."
+                )
+                continue
+            molden = self._molden_path(index)
+            if molden.is_file() and molden.stat().st_size > 0:
+                logger.info(
+                    f"System {index} has energy but no Multiwfn charges; "
+                    "skipping TeraChem and enqueueing Multiwfn"
+                )
+                to_mw.append(atoms)
+            else:
+                logger.warning(
+                    f"System {index} has energy but no Multiwfn charges or molden; "
+                    "re-running TeraChem"
+                )
+                atoms.info["aselmdb_row_id"] = complete[0].id
+                to_qm.append(atoms)
+        return to_qm, to_mw
 
 
 class TeraChemDriver(QMDriver):

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -466,6 +466,48 @@ def test_corrupt_chg_resume_reenqueues_multiwfn(tmp_path: Path, fake_multiwfn):
         np.testing.assert_allclose(qa[0], 0.01)
 
 
+def test_failed_terachem_rerun_preserves_existing_aselmdb_row(tmp_path: Path, fake_multiwfn):
+    """Molden-missing Multiwfn resume must not delete a good energy row if QM fails."""
+    from enerzyme.data.supplier import get_supplier
+
+    sdf = FIXTURES / "fragments_tiny.sdf"
+    common = dict(
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=True,
+        multiwfn_config={"enabled": False},
+    )
+    MoldenFakeQMDriver(supplier=get_supplier(str(sdf), start=0, end=1), **common).run()
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    with connect(str(db_files[0])) as db:
+        assert db.count() == 1
+        energy0 = db.get(index=0).toatoms().get_potential_energy()
+
+    for molden in (tmp_path / "annot_out").rglob("moldens/*.molden"):
+        molden.unlink()
+
+    class FailingDriver(MoldenFakeQMDriver):
+        def collect_results(self, input_file, atoms: Atoms, tmp_dir: Path):
+            raise FileNotFoundError("simulated TeraChem failure")
+
+    FailingDriver(
+        supplier=get_supplier(str(sdf), start=0, end=1),
+        **{**common, "multiwfn_config": _mw_cfg()},
+    ).run()
+
+    with connect(str(db_files[0])) as db:
+        assert db.count() == 1, "failed overwrite must keep the previous energy row"
+        row = db.get(index=0)
+        atoms = row.toatoms()
+        assert atoms.calc.results.get("energy") is not None
+        np.testing.assert_allclose(atoms.get_potential_energy(), energy0)
+        assert "charges" not in (atoms.calc.results or {})
+
+
 def test_stale_chg_cleared_when_terachem_reruns(tmp_path: Path, fake_multiwfn):
     """A leftover .chg must not survive a fresh TeraChem run for the same index."""
     import pickle

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -1,0 +1,334 @@
+"""Unit tests for Multiwfn annotate post-processing (no real TeraChem / Multiwfn)."""
+from __future__ import annotations
+
+import os
+import stat
+import time
+from pathlib import Path
+
+import ase.units
+import numpy as np
+import pytest
+from ase import Atoms
+from ase.db import connect
+
+from enerzyme.qm.multiwfn import (
+    build_multiwfn_stdin,
+    chg_dirname,
+    parse_chg_file,
+    parse_multiwfn_config,
+)
+from enerzyme.qm.qm_driver import QMDriver
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "example" / "L3-COMT-aselmdb-smoke" / "fixtures"
+
+_FAKE_MULTIWFN = r'''#!/usr/bin/env python3
+import os
+import sys
+import time
+from pathlib import Path
+
+molden = Path(sys.argv[1])
+sleep_s = float(os.environ.get("FAKE_MW_SLEEP", "0"))
+if sleep_s > 0:
+    time.sleep(sleep_s)
+n = 2
+if molden.is_file():
+    for line in molden.read_text().splitlines():
+        if line.startswith("NATOMS"):
+            n = int(line.split()[1])
+            break
+log = os.environ.get("FAKE_MW_LOG")
+if log:
+    with open(log, "a") as fh:
+        fh.write(f"mw_end {molden.stem} {time.time():.6f}\n")
+with open(f"{molden.stem}.chg", "w") as fh:
+    for i in range(n):
+        fh.write(f"H    0.000000  0.000000  {float(i):.6f}  {0.01 * (i + 1):.10f}\n")
+'''
+
+
+class MoldenFakeQMDriver(QMDriver):
+    """Writes a stub molden so the Multiwfn queue has a valid input."""
+
+    def make_input(self, atoms: Atoms, tmp_dir: Path):
+        path = tmp_dir / f"{atoms.info['index']}.in"
+        path.write_text("run gradient\nend\n")
+        return path
+
+    def invoke_qm(self, input_file, atoms: Atoms, tmp_dir: Path):
+        log = os.environ.get("FAKE_TC_LOG")
+        if log:
+            with open(log, "a") as fh:
+                fh.write(f"tc_start {atoms.info['index']} {time.time():.6f}\n")
+        out = Path(input_file).with_suffix(".out")
+        out.write_text("ok\n")
+        return out
+
+    def collect_results(self, input_file, atoms: Atoms, tmp_dir: Path):
+        index = Path(input_file).stem
+        n = len(atoms)
+        molden = tmp_dir / f"scr_{index}" / f"{index}.molden"
+        molden.parent.mkdir(parents=True, exist_ok=True)
+        molden.write_text(f"NATOMS {n}\n[Molden Format]\nfake\n")
+        return {
+            "E": -1.0 * ase.units.Ha,
+            "Fa": np.zeros((n, 3)),
+            "M2": np.array([0.1, 0.2, 0.3]),
+            "molden_file": molden,
+        }
+
+
+@pytest.fixture
+def fake_multiwfn(tmp_path: Path, monkeypatch):
+    bindir = tmp_path / "mwbin"
+    bindir.mkdir()
+    exe = bindir / "Multiwfn_noGUI"
+    exe.write_text(_FAKE_MULTIWFN)
+    exe.chmod(exe.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}")
+    return exe
+
+
+def _mw_cfg(**kwargs):
+    cfg = {
+        "enabled": True,
+        "executable": "Multiwfn_noGUI",
+        "charge_method": "1.2cm5",
+        "n_threads": 2,
+        "n_processes": 1,
+        "keep_chg": True,
+    }
+    cfg.update(kwargs)
+    return cfg
+
+
+def test_build_stdin_12cm5_and_cm5():
+    text = build_multiwfn_stdin("1.2cm5")
+    assert text.splitlines() == ["7", "-16", "1", "y", "0", "q"]
+    assert build_multiwfn_stdin("cm5").splitlines() == ["7", "16", "1", "y", "0", "q"]
+    assert build_multiwfn_stdin("hirshfeld").splitlines()[1] == "1"
+    assert build_multiwfn_stdin("adch").splitlines()[1] == "11"
+    assert build_multiwfn_stdin("mulliken").splitlines() == ["7", "5", "1", "y", "0", "0", "q"]
+    assert build_multiwfn_stdin("lowdin").splitlines() == ["7", "6", "", "y", "0", "q"]
+    assert build_multiwfn_stdin("mbis").splitlines()[1] == "20"
+
+
+def test_build_stdin_menu_inputs_override():
+    custom = ["7", "12", "0", "q"]
+    assert build_multiwfn_stdin("1.2cm5", menu_inputs=custom).splitlines() == custom
+
+
+def test_build_stdin_unknown_method():
+    with pytest.raises(ValueError, match="Unknown Multiwfn charge_method"):
+        build_multiwfn_stdin("hirshfeld-i")
+
+
+def test_parse_chg_file(tmp_path: Path):
+    chg = tmp_path / "0.chg"
+    chg.write_text(
+        "O    0.0  0.0  0.0  -0.5\n"
+        "H    0.0  0.0  1.0   0.25\n"
+        "H    0.0  0.0  2.0   0.25\n"
+    )
+    qa = parse_chg_file(chg, n_atoms=3)
+    np.testing.assert_allclose(qa, [-0.5, 0.25, 0.25])
+    with pytest.raises(ValueError, match="2 atoms"):
+        parse_chg_file(chg, n_atoms=2)
+
+
+def test_chg_dirname_12cm5():
+    assert chg_dirname("1.2cm5") == "chrg-12CM5"
+    assert chg_dirname("adch") == "chrg-adch"
+
+
+def test_parse_multiwfn_config_disabled_by_default():
+    assert parse_multiwfn_config(None).enabled is False
+    assert parse_multiwfn_config({"enabled": False}).enabled is False
+    cfg = parse_multiwfn_config({"charge_method": "cm5"})
+    assert cfg.enabled is True
+    assert cfg.charge_method == "cm5"
+
+
+def test_aselmdb_writes_qa(tmp_path: Path, fake_multiwfn):
+    from enerzyme.data.datahub import ASELMDB_METADATA_PROPERTIES_KEY
+    from enerzyme.data.supplier import get_supplier
+
+    supplier = get_supplier(str(FIXTURES / "fragments_tiny.sdf"), start=0, end=2)
+    driver = MoldenFakeQMDriver(
+        supplier=supplier,
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=True,
+        multiwfn_config=_mw_cfg(),
+    )
+    driver.run()
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    assert db_files
+    with connect(str(db_files[0])) as db:
+        assert "Qa" in db.metadata.get(ASELMDB_METADATA_PROPERTIES_KEY, [])
+        assert db.count() == 2
+        for row in db.select():
+            atoms = row.toatoms()
+            qa = atoms.get_charges()
+            assert qa.shape == (len(atoms),)
+            np.testing.assert_allclose(qa[0], 0.01)
+    chg_files = list((tmp_path / "annot_out").rglob("chrg-12CM5/*.chg"))
+    assert len(chg_files) == 2
+
+
+def test_pickle_writes_qa_and_chrg_alias(tmp_path: Path, fake_multiwfn):
+    import pickle
+
+    from enerzyme.data.supplier import SDFSupplier
+
+    supplier = SDFSupplier(str(FIXTURES / "fragments_tiny.sdf"), start=0, end=2)
+    driver = MoldenFakeQMDriver(
+        supplier=supplier,
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        pickle_name="fragments.pkl",
+        pickle_fields={"E": "energy", "Fa": "grad", "M2": "dipole", "Qa": "chrg",
+                       "Ra": "coord", "Za": "atom_type", "Q": "total_chrg", "S": "total_spin"},
+        n_processes=1,
+        clean_tmp=True,
+        multiwfn_config=_mw_cfg(),
+    )
+    driver.run()
+    pkl = list((tmp_path / "annot_out").rglob("fragments.pkl"))
+    assert pkl
+    with open(pkl[0], "rb") as fh:
+        data = pickle.load(fh)
+    assert len(data) == 2
+    assert "chrg" in data[0]
+    assert data[0]["chrg"].shape[0] == data[0]["coord"].shape[0]
+
+
+def test_multiwfn_does_not_block_next_terachem(tmp_path: Path, fake_multiwfn, monkeypatch):
+    from enerzyme.data.supplier import get_supplier
+
+    tc_log = tmp_path / "tc.log"
+    mw_log = tmp_path / "mw.log"
+    monkeypatch.setenv("FAKE_TC_LOG", str(tc_log))
+    monkeypatch.setenv("FAKE_MW_LOG", str(mw_log))
+    monkeypatch.setenv("FAKE_MW_SLEEP", "0.4")
+
+    supplier = get_supplier(str(FIXTURES / "fragments_tiny.sdf"), start=0, end=2)
+    driver = MoldenFakeQMDriver(
+        supplier=supplier,
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=True,
+        multiwfn_config=_mw_cfg(),
+    )
+    driver.run()
+
+    tc = {}
+    for line in tc_log.read_text().splitlines():
+        _, idx, ts = line.split()
+        tc[int(idx)] = float(ts)
+    mw = {}
+    for line in mw_log.read_text().splitlines():
+        _, idx, ts = line.split()
+        mw[int(idx)] = float(ts)
+    assert 0 in tc and 1 in tc and 0 in mw
+    assert tc[1] < mw[0], (
+        "TeraChem for structure 1 must start before Multiwfn for structure 0 finishes"
+    )
+
+
+def test_aselmdb_resume_skips_qm_runs_multiwfn_only(tmp_path: Path, fake_multiwfn):
+    from enerzyme.data.supplier import get_supplier
+
+    sdf = FIXTURES / "fragments_tiny.sdf"
+    common = dict(
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=True,
+    )
+    call_count = {"n": 0}
+
+    class CountingDriver(MoldenFakeQMDriver):
+        def collect_results(self, input_file, atoms: Atoms, tmp_dir: Path):
+            call_count["n"] += 1
+            return super().collect_results(input_file, atoms, tmp_dir)
+
+    CountingDriver(
+        supplier=get_supplier(str(sdf), start=0, end=1),
+        multiwfn_config={"enabled": False},
+        **common,
+    ).run()
+    assert call_count["n"] == 1
+
+    call_count["n"] = 0
+    CountingDriver(
+        supplier=get_supplier(str(sdf), start=0, end=1),
+        multiwfn_config=_mw_cfg(),
+        **common,
+    ).run()
+    assert call_count["n"] == 0, "resume must not re-run TeraChem when molden exists"
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    with connect(str(db_files[0])) as db:
+        atoms = db.get(index=0).toatoms()
+        assert atoms.get_charges() is not None
+        assert len(atoms.get_charges()) == len(atoms)
+
+
+def test_multiprocess_qm_and_multiwfn(tmp_path: Path, fake_multiwfn):
+    from enerzyme.data.supplier import get_supplier
+
+    supplier = get_supplier(str(FIXTURES / "fragments_tiny.sdf"), start=0, end=3)
+    driver = MoldenFakeQMDriver(
+        supplier=supplier,
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=2,
+        clean_tmp=True,
+        keep_molden=True,
+        multiwfn_config=_mw_cfg(n_processes=2),
+    )
+    driver.run()
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    with connect(str(db_files[0])) as db:
+        assert db.count() == 3
+        for row in db.select():
+            assert row.toatoms().get_charges() is not None
+
+
+def test_disabled_multiwfn_does_not_require_binary(tmp_path: Path):
+    """enabled:false must match the pre-Multiwfn annotate path (no executable)."""
+    from enerzyme.data.supplier import get_supplier
+
+    supplier = get_supplier(str(FIXTURES / "fragments_tiny.sdf"), start=0, end=1)
+    driver = MoldenFakeQMDriver(
+        supplier=supplier,
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        multiwfn_config={"enabled": False},
+    )
+    driver.run()
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    assert db_files
+    with connect(str(db_files[0])) as db:
+        atoms = db.get(index=0).toatoms()
+        assert "charges" not in (atoms.calc.results or {})

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -386,3 +386,50 @@ def test_pickle_resume_uses_existing_chg_without_rerunning_qm(tmp_path: Path, fa
         data = pickle.load(fh)
     expected = parse_chg_file(chg_files[0])
     np.testing.assert_allclose(data[0]["Qa"], expected)
+
+
+def test_stale_chg_cleared_when_terachem_reruns(tmp_path: Path, fake_multiwfn):
+    """A leftover .chg must not survive a fresh TeraChem run for the same index."""
+    import pickle
+
+    from enerzyme.data.supplier import SDFSupplier
+
+    sdf = FIXTURES / "fragments_tiny.sdf"
+    common = dict(
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        pickle_name="fragments.pkl",
+        dump_single_run=True,
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=False,
+        multiwfn_config=_mw_cfg(),
+    )
+    driver = MoldenFakeQMDriver(
+        supplier=SDFSupplier(str(sdf), start=0, end=1),
+        **common,
+    )
+    driver.run()
+
+    out_root = tmp_path / "annot_out" / "fragments_tiny_0_1"
+    chg_path = out_root / "chrg-12CM5" / "0.chg"
+    assert chg_path.is_file()
+    n_atoms = len(SDFSupplier(str(sdf), start=0, end=1).suppl().__next__())
+    stale = np.full(n_atoms, 9.99)
+    with open(chg_path, "w") as fh:
+        for i, q in enumerate(stale):
+            fh.write(f"H  0.0  0.0  {float(i):.6f}  {q:.10f}\n")
+
+    for path in out_root.rglob("single_run/*.pkl"):
+        path.unlink()
+    for path in out_root.rglob("moldens/*.molden"):
+        path.unlink()
+
+    MoldenFakeQMDriver(supplier=SDFSupplier(str(sdf), start=0, end=1), **common).run()
+    pkl = list(out_root.rglob("fragments.pkl"))
+    with open(pkl[0], "rb") as fh:
+        data = pickle.load(fh)
+    qa = np.asarray(data[0]["Qa"], dtype=float)
+    assert not np.allclose(qa, 9.99), "stale .chg must not be merged after TeraChem rerun"
+    np.testing.assert_allclose(qa[0], 0.01)

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -417,6 +417,55 @@ def test_invoke_multiwfn_rejects_stale_workdir_chg(tmp_path: Path, fake_multiwfn
     assert not stale.exists(), "stale workdir .chg must be cleared before Multiwfn runs"
 
 
+def test_corrupt_chg_resume_reenqueues_multiwfn(tmp_path: Path, fake_multiwfn):
+    """A truncated/corrupt .chg must not permanently block charge recovery."""
+    from enerzyme.data.supplier import get_supplier
+
+    sdf = FIXTURES / "fragments_tiny.sdf"
+    common = dict(
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        output_file="fragments.aselmdb",
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=True,
+        multiwfn_config=_mw_cfg(),
+    )
+    call_count = {"n": 0}
+
+    class CountingDriver(MoldenFakeQMDriver):
+        def collect_results(self, input_file, atoms: Atoms, tmp_dir: Path):
+            call_count["n"] += 1
+            return super().collect_results(input_file, atoms, tmp_dir)
+
+    CountingDriver(supplier=get_supplier(str(sdf), start=0, end=1), **common).run()
+    assert call_count["n"] == 1
+
+    db_files = list((tmp_path / "annot_out").rglob("*.aselmdb"))
+    with connect(str(db_files[0])) as db:
+        atoms = db.get(index=0).toatoms()
+        results = dict(atoms.calc.results)
+        results.pop("charges", None)
+        from ase.calculators.singlepoint import SinglePointCalculator
+
+        atoms.calc = SinglePointCalculator(atoms=atoms, **results)
+        row = db.get(index=0)
+        db.write(atoms, id=row.id, data=dict(row.data), index=0)
+
+    chg_path = next((tmp_path / "annot_out").rglob("chrg-12CM5/0.chg"))
+    chg_path.write_text("not a valid charge file\n")
+    assert list((tmp_path / "annot_out").rglob("moldens/0.molden"))
+
+    call_count["n"] = 0
+    CountingDriver(supplier=get_supplier(str(sdf), start=0, end=1), **common).run()
+    assert call_count["n"] == 0, "corrupt .chg with molden must not re-run TeraChem"
+    with connect(str(db_files[0])) as db:
+        qa = db.get(index=0).toatoms().get_charges()
+        assert qa is not None
+        np.testing.assert_allclose(qa[0], 0.01)
+
+
 def test_stale_chg_cleared_when_terachem_reruns(tmp_path: Path, fake_multiwfn):
     """A leftover .chg must not survive a fresh TeraChem run for the same index."""
     import pickle

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -388,6 +388,35 @@ def test_pickle_resume_uses_existing_chg_without_rerunning_qm(tmp_path: Path, fa
     np.testing.assert_allclose(data[0]["Qa"], expected)
 
 
+def test_invoke_multiwfn_rejects_stale_workdir_chg(tmp_path: Path, fake_multiwfn):
+    """Leftover workdir .chg must not count as success when Multiwfn fails."""
+    from enerzyme.qm.multiwfn import invoke_multiwfn
+
+    molden = tmp_path / "0.molden"
+    molden.write_text("NATOMS 2\n[Molden Format]\nfake\n")
+    workdir = tmp_path / "multiwfn_tmp" / "0"
+    workdir.mkdir(parents=True)
+    stale = workdir / "0.chg"
+    stale.write_text("H  0.0  0.0  0.0  9.9900000000\nH  0.0  0.0  1.0  9.9900000000\n")
+
+    fail_exe = tmp_path / "mwbin" / "Multiwfn_fail"
+    fail_exe.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.exit(1)\n"
+    )
+    fail_exe.chmod(fail_exe.stat().st_mode | stat.S_IEXEC)
+
+    with pytest.raises(RuntimeError, match="exited with code 1"):
+        invoke_multiwfn(
+            molden=molden,
+            workdir=workdir,
+            n_threads=1,
+            executable=str(fail_exe),
+        )
+    assert not stale.exists(), "stale workdir .chg must be cleared before Multiwfn runs"
+
+
 def test_stale_chg_cleared_when_terachem_reruns(tmp_path: Path, fake_multiwfn):
     """A leftover .chg must not survive a fresh TeraChem run for the same index."""
     import pickle

--- a/test/test_multiwfn_annotate.py
+++ b/test/test_multiwfn_annotate.py
@@ -332,3 +332,57 @@ def test_disabled_multiwfn_does_not_require_binary(tmp_path: Path):
     with connect(str(db_files[0])) as db:
         atoms = db.get(index=0).toatoms()
         assert "charges" not in (atoms.calc.results or {})
+    assert not list((tmp_path / "annot_out").rglob("moldens/*.molden")), (
+        "keep_molden=false and Multiwfn off must not stage moldens"
+    )
+
+
+def test_pickle_resume_uses_existing_chg_without_rerunning_qm(tmp_path: Path, fake_multiwfn):
+    """If Multiwfn wrote .chg but pickle merge never ran, resume must not re-run TeraChem."""
+    import pickle
+
+    from enerzyme.data.supplier import SDFSupplier
+
+    sdf = FIXTURES / "fragments_tiny.sdf"
+    call_count = {"n": 0}
+
+    class CountingDriver(MoldenFakeQMDriver):
+        def collect_results(self, input_file, atoms: Atoms, tmp_dir: Path):
+            call_count["n"] += 1
+            return super().collect_results(input_file, atoms, tmp_dir)
+
+    common = dict(
+        tmp_dir=str(tmp_path / "annot_tmp"),
+        output_dir=str(tmp_path / "annot_out"),
+        template_input_file=str(FIXTURES / "terachem_template.in"),
+        pickle_name="fragments.pkl",
+        dump_single_run=True,
+        n_processes=1,
+        clean_tmp=True,
+        keep_molden=False,
+        multiwfn_config=_mw_cfg(),
+    )
+    CountingDriver(supplier=SDFSupplier(str(sdf), start=0, end=1), **common).run()
+    assert call_count["n"] == 1
+
+    single_runs = list((tmp_path / "annot_out").rglob("single_run/0.pkl"))
+    assert single_runs
+    with open(single_runs[0], "rb") as fh:
+        cached = pickle.load(fh)
+    cached.pop("Qa", None)
+    with open(single_runs[0], "wb") as fh:
+        pickle.dump(cached, fh)
+    for molden in (tmp_path / "annot_out").rglob("moldens/*.molden"):
+        molden.unlink()
+    chg_files = list((tmp_path / "annot_out").rglob("chrg-12CM5/0.chg"))
+    assert chg_files, "resume fixture requires the Multiwfn .chg to survive"
+
+    call_count["n"] = 0
+    CountingDriver(supplier=SDFSupplier(str(sdf), start=0, end=1), **common).run()
+    assert call_count["n"] == 0, "existing .chg must skip TeraChem even without a molden"
+
+    pkl = list((tmp_path / "annot_out").rglob("fragments.pkl"))
+    with open(pkl[0], "rb") as fh:
+        data = pickle.load(fh)
+    expected = parse_chg_file(chg_files[0])
+    np.testing.assert_allclose(data[0]["Qa"], expected)


### PR DESCRIPTION
## Summary
- Optional top-level `Multiwfn` config runs `Multiwfn_noGUI` on TeraChem moldens and writes atomic charges as `Qa` (ASE `charges` / pickle `Qa` or `pickle_fields.Qa`).
- TeraChem GPU workers copy a valid molden and enqueue Multiwfn immediately, so a charge job never occupies a QC process. Multiwfn workers only write `.chg`; the parent merges after the pool joins (ASE LMDB has no working lock file).
- `n_threads` is OpenMP/`-nt` per process; `n_processes` is concurrent Multiwfn jobs (default 1). Default `charge_method` is `1.2cm5` (`7 / -16 / 1 / y`). Load a noGUI Multiwfn module in the job script alongside TeraChem.

## Test plan
- [x] `pytest test/test_multiwfn_annotate.py` (stdin recipes, `.chg` parse, aselmdb/pickle `Qa`, async invariant, resume Multiwfn-only, multiprocess queue)
- [x] `pytest test/test_aselmdb_al_smoke.py` (existing annotate path unchanged when Multiwfn is off)
- [ ] On a GPU node: `module load` TeraChem + `multiwfn/*-noGui`, run `enerzyme annotate` with `Multiwfn.enabled: true` on a short slice and confirm `chrg-12CM5/` and `Qa` in the output


Made with [Cursor](https://cursor.com)